### PR TITLE
first try at a function to break 1D-daily into 2D for seasons

### DIFF
--- a/onset_maproom/calc.py
+++ b/onset_maproom/calc.py
@@ -95,11 +95,6 @@ def daily_tobegroupedby_season(
     if start_day == 29 and start_month == 2:
         start_day = 1
         start_month = 3
-    end_day2 = end_day
-    end_month2 = end_month
-    if end_day == 29 and end_month == 2:
-        end_day2 = 1
-        end_month2 = 3
     # Find seasons edges
     start_edges = daily_data[time_coord].where(
         lambda x: (x.dt.day == start_day) & (x.dt.month == start_month),
@@ -108,22 +103,22 @@ def daily_tobegroupedby_season(
     if end_day == 29 and end_month == 2:
         end_edges = daily_data[time_coord].where(
             lambda x: (
-                (x + xr.DataArray([1]).astype("timedelta64[D]")).dt.day.squeeze(
+                (x + np.timedelta64(1, "D")).dt.day.squeeze(
                     drop=True
                 )
-                == end_day2
+                == 1 
             )
             & (
-                (x + xr.DataArray([1]).astype("timedelta64[D]")).dt.month.squeeze(
+                (x + np.timedelta64(1, "D")).dt.month.squeeze(
                     drop=True
                 )
-                == end_month2
+                == 3
             ),
             drop=True,
         )
     else:
         end_edges = daily_data[time_coord].where(
-            lambda x: (x.dt.day == end_day2) & (x.dt.month == end_month2),
+            lambda x: (x.dt.day == end_day) & (x.dt.month == end_month),
             drop=True,
         )
     # Drop dates outside very first and very last edges

--- a/onset_maproom/calc.py
+++ b/onset_maproom/calc.py
@@ -111,8 +111,6 @@ def daily_tobegroupedby_season(daily_data, start_day, start_month, end_day, end_
 def seasonal_sum(daily_data, start_day, start_month, end_day, end_month, min_count=None, time_coord="T"):
     """Calculates seasonal totals of daily data in season defined by day-month edges
     """
-    #It turns out that having daily_groupby_season concatenate only every other group is not enough to drop entired the undesired seasons
-    #sum will return NaN for these so need to use dropna to clean up
     grouped_daily_data = daily_tobegroupedby_season(daily_data, start_day, start_month, end_day, end_month)
     seasonal_data = (
       grouped_daily_data[daily_data.name]

--- a/onset_maproom/calc.py
+++ b/onset_maproom/calc.py
@@ -2,15 +2,30 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
-#Date Reading functions
+# Date Reading functions
+
 
 def read_zarr_data(zarr_path):
     zarr_data = xr.open_zarr(zarr_path)
     return zarr_data
 
-#Growing season functions
 
-def onset_date(daily_rain, early_start_day, early_start_month, search_days, rainy_day, running_days, running_total, min_rainy_days, dry_days, dry_spell, time_coord="T"):
+# Growing season functions
+
+
+def onset_date(
+    daily_rain,
+    early_start_day,
+    early_start_month,
+    search_days,
+    rainy_day,
+    running_days,
+    running_total,
+    min_rainy_days,
+    dry_days,
+    dry_spell,
+    time_coord="T",
+):
     """Function reproducing Ingrid onsetDate function
     http://iridl.ldeo.columbia.edu/dochelp/Documentation/details/index.html?func=onsetDate
     with the exception that:
@@ -19,25 +34,30 @@ def onset_date(daily_rain, early_start_day, early_start_month, search_days, rain
     output is now the timedelta with each year's earlyStart (as opposed to the date itself)
     """
     onset_date = daily_rain[
-      (daily_rain[time_coord].dt.day==early_start_day)
-      &
-      (daily_rain[time_coord].dt.month==early_start_month)
+        (daily_rain[time_coord].dt.day == early_start_day)
+        & (daily_rain[time_coord].dt.month == early_start_month)
     ]
     onset_date = xr.DataArray(
-      data=np.random.randint(0, high=search_days, size=onset_date.shape).astype('timedelta64[D]'),
-      dims=onset_date.dims,
-      coords=onset_date.coords,
-      attrs=dict(
-          description="Onset Date",
-      ),
+        data=np.random.randint(0, high=search_days, size=onset_date.shape).astype(
+            "timedelta64[D]"
+        ),
+        dims=onset_date.dims,
+        coords=onset_date.coords,
+        attrs=dict(
+            description="Onset Date",
+        ),
     )
-   #Tip to get dates from timedelta  early_start_day
-   #  onset_date = onset_date[time_coord] + onset_date  
+    # Tip to get dates from timedelta  early_start_day
+    #  onset_date = onset_date[time_coord] + onset_date
     return onset_date
+
 
 # Time functions
 
-def daily_tobegroupedby_season(daily_data, start_day, start_month, end_day, end_month, time_coord="T"):
+
+def daily_tobegroupedby_season(
+    daily_data, start_day, start_month, end_day, end_month, time_coord="T"
+):
     """Returns dataset ready to be grouped by with:
     the daily data where all days not in season of interest are dropped
     season_starts: an array where the non-dropped days are indexed by the first day of their season -- to use to groupby
@@ -47,83 +67,112 @@ def daily_tobegroupedby_season(daily_data, start_day, start_month, end_day, end_
     If ending day-month is 29-Feb, uses 1-Mar and triggers the option to open the right edge of the Interval.
     That means that the last day included in the season will be 29-Feb in leap years and 28-Feb otherwise
     """
-    #Deal with leap year cases
-    if start_day == 29 and start_month == 2 :
-      start_day = 1
-      start_month = 3
+    # Deal with leap year cases
+    if start_day == 29 and start_month == 2:
+        start_day = 1
+        start_month = 3
     end_day2 = end_day
     end_month2 = end_month
-    if end_day == 29 and end_month == 2 :
-      end_day2 = 1
-      end_month2 = 3
+    if end_day == 29 and end_month == 2:
+        end_day2 = 1
+        end_month2 = 3
     start_edges = daily_data[time_coord].where(
-      ((daily_data[time_coord].dt.day==start_day) & (daily_data[time_coord].dt.month==start_month)),
-      drop=True
+        (
+            (daily_data[time_coord].dt.day == start_day)
+            & (daily_data[time_coord].dt.month == start_month)
+        ),
+        drop=True,
     )
     end_edges = daily_data[time_coord].where(
-      ((daily_data[time_coord].dt.day==end_day2) & (daily_data[time_coord].dt.month==end_month2)),
-      drop=True
+        (
+            (daily_data[time_coord].dt.day == end_day2)
+            & (daily_data[time_coord].dt.month == end_month2)
+        ),
+        drop=True,
     )
-    #Drop date outside very first and very last edges -- this ensures we get complete seasons with regards to edges, later on
-    daily_data = daily_data.sel(**{time_coord: slice(start_edges[0],end_edges[-1])})
+    # Drop date outside very first and very last edges -- this ensures we get complete seasons with regards to edges, later on
+    daily_data = daily_data.sel(**{time_coord: slice(start_edges[0], end_edges[-1])})
     start_edges = daily_data[time_coord].where(
-      ((daily_data[time_coord].dt.day==start_day) & (daily_data[time_coord].dt.month==start_month)),
-      drop=True
+        (
+            (daily_data[time_coord].dt.day == start_day)
+            & (daily_data[time_coord].dt.month == start_month)
+        ),
+        drop=True,
     )
     end_edges = daily_data[time_coord].where(
-      ((daily_data[time_coord].dt.day==end_day2) & (daily_data[time_coord].dt.month==end_month2)),
-      drop=True
+        (
+            (daily_data[time_coord].dt.day == end_day2)
+            & (daily_data[time_coord].dt.month == end_month2)
+        ),
+        drop=True,
     )
-    #Creates array of edges of the season that will form the bins
+    # Creates array of edges of the season that will form the bins
     seasons_edges = xr.concat([start_edges, end_edges], "T_out", join="override")
-    #Creates seasons_starts that will be used for grouping
-    #and seasons_ends that is one of the outputs
-    if end_day == 29 and end_month == 2 :
-      days_in_season = (
-        daily_data[time_coord] >= seasons_edges.isel(T_out=0).rename({time_coord: "group"})
-      ) & (
-        daily_data[time_coord] < seasons_edges.isel(T_out=1).rename({time_coord: "group"})
-      )
+    # Creates seasons_starts that will be used for grouping
+    # and seasons_ends that is one of the outputs
+    if end_day == 29 and end_month == 2:
+        days_in_season = (
+            daily_data[time_coord]
+            >= seasons_edges.isel(T_out=0).rename({time_coord: "group"})
+        ) & (
+            daily_data[time_coord]
+            < seasons_edges.isel(T_out=1).rename({time_coord: "group"})
+        )
     else:
-      days_in_season = (
-        daily_data[time_coord] >= seasons_edges.isel(T_out=0).rename({time_coord: "group"})
-      ) & (
-        daily_data[time_coord] <= seasons_edges.isel(T_out=1).rename({time_coord: "group"})
-      )
+        days_in_season = (
+            daily_data[time_coord]
+            >= seasons_edges.isel(T_out=0).rename({time_coord: "group"})
+        ) & (
+            daily_data[time_coord]
+            <= seasons_edges.isel(T_out=1).rename({time_coord: "group"})
+        )
     seasons_starts = daily_data[time_coord].where(days_in_season)
     seasons_starts = (
-      xr.where(seasons_starts >= seasons_starts["group"], seasons_starts["group"], seasons_starts)
-      .min(dim="group", skipna=True)
-      .dropna(dim=time_coord)
-      .rename("seasons_starts")
+        xr.where(
+            seasons_starts >= seasons_starts["group"],
+            seasons_starts["group"],
+            seasons_starts,
+        )
+        .min(dim="group", skipna=True)
+        .dropna(dim=time_coord)
+        .rename("seasons_starts")
     )
     seasons_ends = (
-      daily_data[time_coord].where(days_in_season)
-      .max(dim="T", skipna=True)
-      .rename("seasons_ends")
+        daily_data[time_coord]
+        .where(days_in_season)
+        .max(dim="T", skipna=True)
+        .rename("seasons_ends")
     )
-    #Drops daily data not in seasons of interest
+    # Drops daily data not in seasons of interest
     daily_data = daily_data.where(seasons_starts, drop=True)
-    #Group by season with groups labeled by seasons_starts
+    # Group by season with groups labeled by seasons_starts
     daily_tobegroupedby_season = xr.merge([daily_data, seasons_starts, seasons_ends])
     return daily_tobegroupedby_season
 
-def seasonal_sum(daily_data, start_day, start_month, end_day, end_month, min_count=None, time_coord="T"):
-    """Calculates seasonal totals of daily data in season defined by day-month edges
-    """
-    grouped_daily_data = daily_tobegroupedby_season(daily_data, start_day, start_month, end_day, end_month)
+
+def seasonal_sum(
+    daily_data,
+    start_day,
+    start_month,
+    end_day,
+    end_month,
+    min_count=None,
+    time_coord="T",
+):
+    """Calculates seasonal totals of daily data in season defined by day-month edges"""
+    grouped_daily_data = daily_tobegroupedby_season(
+        daily_data, start_day, start_month, end_day, end_month
+    )
     seasonal_data = (
-      grouped_daily_data[daily_data.name]
-      .groupby(grouped_daily_data["seasons_starts"])
-      .sum(dim=time_coord, skipna=True, min_count=min_count)
-      .rename({"seasons_starts": time_coord})
+        grouped_daily_data[daily_data.name]
+        .groupby(grouped_daily_data["seasons_starts"])
+        .sum(dim=time_coord, skipna=True, min_count=min_count)
+        .rename({"seasons_starts": time_coord})
     )
-    seasons_ends = (
-      grouped_daily_data["seasons_ends"]
-      .rename({"group": time_coord})
-    )
+    seasons_ends = grouped_daily_data["seasons_ends"].rename({"group": time_coord})
     summed_seasons = xr.merge([seasonal_data, seasons_ends])
     return summed_seasons
+
 
 def run_test_season_stuff():
     import pyaconf
@@ -137,37 +186,36 @@ def run_test_season_stuff():
     rr_mrg = rr_mrg.sel(T=slice("2000", "2004"))
 
     print("the inputs to grouping")
-    print(
-      daily_tobegroupedby_season(rr_mrg.precip, 29, 11, 5, 2)
-    )
+    print(daily_tobegroupedby_season(rr_mrg.precip, 29, 11, 5, 2))
 
     print("the outputs of seasonal_sum")
-    print(
-      seasonal_sum(rr_mrg.precip, 29, 11, 5, 2, min_count=0)
-    )
+    print(seasonal_sum(rr_mrg.precip, 29, 11, 5, 2, min_count=0))
 
     print("some data")
     print(
-      seasonal_sum(rr_mrg.precip, 29, 11, 5, 2, min_count=0).precip.isel(X=150, Y=150).values
+        seasonal_sum(rr_mrg.precip, 29, 11, 5, 2, min_count=0)
+        .precip.isel(X=150, Y=150)
+        .values
     )
+
 
 def strftimeb2int(strftimeb):
     strftimeb_all = {
-      "Jan": 1,
-      "Feb": 2,
-      "Mar": 3,
-      "Apr": 4,
-      "May": 5,
-      "Jun": 6,
-      "Jul": 7,
-      "Aug": 8,
-      "Sep": 9,
-      "Oct": 10,
-      "Nov": 11,
-      "Dec": 12
+        "Jan": 1,
+        "Feb": 2,
+        "Mar": 3,
+        "Apr": 4,
+        "May": 5,
+        "Jun": 6,
+        "Jul": 7,
+        "Aug": 8,
+        "Sep": 9,
+        "Oct": 10,
+        "Nov": 11,
+        "Dec": 12,
     }
-    strftimebint=strftimeb_all[strftimeb]
+    strftimebint = strftimeb_all[strftimeb]
     return strftimebint
 
-run_test_season_stuff()
 
+run_test_season_stuff()

--- a/onset_maproom/calc.py
+++ b/onset_maproom/calc.py
@@ -5,170 +5,170 @@ import xarray as xr
 #Date Reading functions
 
 def read_zarr_data(zarr_path):
-  zarr_data = xr.open_zarr(zarr_path)
-  return zarr_data
+    zarr_data = xr.open_zarr(zarr_path)
+    return zarr_data
 
 #Growing season functions
 
 def onset_date(daily_rain, early_start_day, early_start_month, search_days, rainy_day, running_days, running_total, min_rainy_days, dry_days, dry_spell, time_coord="T"):
-  """Function reproducing Ingrid onsetDate function
-  http://iridl.ldeo.columbia.edu/dochelp/Documentation/details/index.html?func=onsetDate
-  with the exception that:
-  output is a random deltatime rather than an actual onset
-  earlyStart input is now 2 arguments: day and month (as opposed to 1)
-  output is now the timedelta with each year's earlyStart (as opposed to the date itself)
-  """
-  onset_date = daily_rain[
-    (daily_rain[time_coord].dt.day==early_start_day)
-    &
-    (daily_rain[time_coord].dt.month==early_start_month)
-  ]
-  onset_date = xr.DataArray(
-    data=np.random.randint(0, high=search_days, size=onset_date.shape).astype('timedelta64[D]'),
-    dims=onset_date.dims,
-    coords=onset_date.coords,
-    attrs=dict(
-        description="Onset Date",
-    ),
-  )
-#Tip to get dates from timedelta  early_start_day
-#  onset_date = onset_date[time_coord] + onset_date  
-  return onset_date
+    """Function reproducing Ingrid onsetDate function
+    http://iridl.ldeo.columbia.edu/dochelp/Documentation/details/index.html?func=onsetDate
+    with the exception that:
+    output is a random deltatime rather than an actual onset
+    earlyStart input is now 2 arguments: day and month (as opposed to 1)
+    output is now the timedelta with each year's earlyStart (as opposed to the date itself)
+    """
+    onset_date = daily_rain[
+      (daily_rain[time_coord].dt.day==early_start_day)
+      &
+      (daily_rain[time_coord].dt.month==early_start_month)
+    ]
+    onset_date = xr.DataArray(
+      data=np.random.randint(0, high=search_days, size=onset_date.shape).astype('timedelta64[D]'),
+      dims=onset_date.dims,
+      coords=onset_date.coords,
+      attrs=dict(
+          description="Onset Date",
+      ),
+    )
+   #Tip to get dates from timedelta  early_start_day
+   #  onset_date = onset_date[time_coord] + onset_date  
+    return onset_date
 
 # Time functions
 
 def daily_tobegroupedby_season(daily_data, start_day, start_month, end_day, end_month, time_coord="T"):
-  """Returns dataset ready to be grouped by with:
-  the daily data where all days not in season of interest are dropped
-  season_starts: an array where the non-dropped days are indexed by the first day of their season -- to use to groupby
-  seasons_ends: an array with the dates of the end of the seasons
-  Can then apply groupby on daily_data against seasons_starts, and preserving seasons_ends for the record
-  If starting day-month is 29-Feb, uses 1-Mar.
-  If ending day-month is 29-Feb, uses 1-Mar and triggers the option to open the right edge of the Interval.
-  That means that the last day included in the season will be 29-Feb in leap years and 28-Feb otherwise
-  """
-  #Deal with leap year cases
-  if start_day == 29 and start_month == 2 :
-    start_day = 1
-    start_month = 3
-  end_day2 = end_day
-  end_month2 = end_month
-  if end_day == 29 and end_month == 2 :
-    end_day2 = 1
-    end_month2 = 3
-  #Drop date outside very first and very last edges -- this ensures we get complete seasons with regards to edges, later on
-  start_edges = daily_data[time_coord].where(
-    ((daily_data[time_coord].dt.day==start_day) & (daily_data[time_coord].dt.month==start_month)),
-    drop=True
-  )
-  end_edges = daily_data[time_coord].where(
-    ((daily_data[time_coord].dt.day==end_day2) & (daily_data[time_coord].dt.month==end_month2)),
-    drop=True
-  )
-  daily_data = daily_data.sel(**{time_coord: slice(start_edges[0],end_edges[-1])})
-  start_edges = daily_data[time_coord].where(
-    ((daily_data[time_coord].dt.day==start_day) & (daily_data[time_coord].dt.month==start_month)),
-    drop=True
-  )
-  end_edges = daily_data[time_coord].where(
-    ((daily_data[time_coord].dt.day==end_day2) & (daily_data[time_coord].dt.month==end_month2)),
-    drop=True
-  )
-  #Creates array of edges of the season that will form the bins
-  seasons_edges = xr.concat([start_edges, end_edges], "T_out", join="override")
-  #Creates seasons_starts that will be used for grouping
-  #and seasons_ends that is one of the outputs
-  if end_day == 29 and end_month == 2 :
-    days_in_season = (
-      daily_data[time_coord] >= seasons_edges.isel(T_out=0).rename({time_coord: "group"})
-    ) & (
-      daily_data[time_coord] < seasons_edges.isel(T_out=1).rename({time_coord: "group"})
+    """Returns dataset ready to be grouped by with:
+    the daily data where all days not in season of interest are dropped
+    season_starts: an array where the non-dropped days are indexed by the first day of their season -- to use to groupby
+    seasons_ends: an array with the dates of the end of the seasons
+    Can then apply groupby on daily_data against seasons_starts, and preserving seasons_ends for the record
+    If starting day-month is 29-Feb, uses 1-Mar.
+    If ending day-month is 29-Feb, uses 1-Mar and triggers the option to open the right edge of the Interval.
+    That means that the last day included in the season will be 29-Feb in leap years and 28-Feb otherwise
+    """
+    #Deal with leap year cases
+    if start_day == 29 and start_month == 2 :
+      start_day = 1
+      start_month = 3
+    end_day2 = end_day
+    end_month2 = end_month
+    if end_day == 29 and end_month == 2 :
+      end_day2 = 1
+      end_month2 = 3
+    #Drop date outside very first and very last edges -- this ensures we get complete seasons with regards to edges, later on
+    start_edges = daily_data[time_coord].where(
+      ((daily_data[time_coord].dt.day==start_day) & (daily_data[time_coord].dt.month==start_month)),
+      drop=True
     )
-  else:
-    days_in_season = (
-      daily_data[time_coord] >= seasons_edges.isel(T_out=0).rename({time_coord: "group"})
-    ) & (
-      daily_data[time_coord] <= seasons_edges.isel(T_out=1).rename({time_coord: "group"})
+    end_edges = daily_data[time_coord].where(
+      ((daily_data[time_coord].dt.day==end_day2) & (daily_data[time_coord].dt.month==end_month2)),
+      drop=True
     )
-  seasons_starts = daily_data[time_coord].where(days_in_season)
-  seasons_starts = (
-    xr.where(seasons_starts >= seasons_starts["group"], seasons_starts["group"], seasons_starts)
-    .min(dim="group", skipna=True)
-    .dropna(dim=time_coord)
-    .rename("seasons_starts")
-  )
-  seasons_ends = (
-    daily_data[time_coord].where(days_in_season)
-    .max(dim="T", skipna=True)
-    .rename("seasons_ends")
-  )
-  #Drops daily data not in seasons of interest
-  daily_data = daily_data.where(seasons_starts, drop=True)
-  #Group by season with groups labeled by seasons_starts
-  daily_tobegroupedby_season = xr.merge([daily_data, seasons_starts, seasons_ends])
-  return daily_tobegroupedby_season
+    daily_data = daily_data.sel(**{time_coord: slice(start_edges[0],end_edges[-1])})
+    start_edges = daily_data[time_coord].where(
+      ((daily_data[time_coord].dt.day==start_day) & (daily_data[time_coord].dt.month==start_month)),
+      drop=True
+    )
+    end_edges = daily_data[time_coord].where(
+      ((daily_data[time_coord].dt.day==end_day2) & (daily_data[time_coord].dt.month==end_month2)),
+      drop=True
+    )
+    #Creates array of edges of the season that will form the bins
+    seasons_edges = xr.concat([start_edges, end_edges], "T_out", join="override")
+    #Creates seasons_starts that will be used for grouping
+    #and seasons_ends that is one of the outputs
+    if end_day == 29 and end_month == 2 :
+      days_in_season = (
+        daily_data[time_coord] >= seasons_edges.isel(T_out=0).rename({time_coord: "group"})
+      ) & (
+        daily_data[time_coord] < seasons_edges.isel(T_out=1).rename({time_coord: "group"})
+      )
+    else:
+      days_in_season = (
+        daily_data[time_coord] >= seasons_edges.isel(T_out=0).rename({time_coord: "group"})
+      ) & (
+        daily_data[time_coord] <= seasons_edges.isel(T_out=1).rename({time_coord: "group"})
+      )
+    seasons_starts = daily_data[time_coord].where(days_in_season)
+    seasons_starts = (
+      xr.where(seasons_starts >= seasons_starts["group"], seasons_starts["group"], seasons_starts)
+      .min(dim="group", skipna=True)
+      .dropna(dim=time_coord)
+      .rename("seasons_starts")
+    )
+    seasons_ends = (
+      daily_data[time_coord].where(days_in_season)
+      .max(dim="T", skipna=True)
+      .rename("seasons_ends")
+    )
+    #Drops daily data not in seasons of interest
+    daily_data = daily_data.where(seasons_starts, drop=True)
+    #Group by season with groups labeled by seasons_starts
+    daily_tobegroupedby_season = xr.merge([daily_data, seasons_starts, seasons_ends])
+    return daily_tobegroupedby_season
 
 def seasonal_sum(daily_data, start_day, start_month, end_day, end_month, min_count=None, time_coord="T"):
-  """Calculates seasonal totals of daily data in season defined by day-month edges
-  """
-  #It turns out that having daily_groupby_season concatenate only every other group is not enough to drop entired the undesired seasons
-  #sum will return NaN for these so need to use dropna to clean up
-  seasonal_data = (
-    daily_tobegroupedby_season(daily_data, start_day, start_month, end_day, end_month)[daily_data.name]
-    .groupby(daily_tobegroupedby_season(daily_data, start_day, start_month, end_day, end_month)["seasons_starts"])
-    .sum(dim=time_coord, skipna=True, min_count=min_count)
-    .rename({"seasons_starts": time_coord})
-  )
-  seasons_ends = (
-    daily_tobegroupedby_season(daily_data, start_day, start_month, end_day, end_month)["seasons_ends"]
-    .rename({"group": time_coord})
-  )
-  summed_seasons = xr.merge([seasonal_data, seasons_ends])
-  return summed_seasons
+    """Calculates seasonal totals of daily data in season defined by day-month edges
+    """
+    #It turns out that having daily_groupby_season concatenate only every other group is not enough to drop entired the undesired seasons
+    #sum will return NaN for these so need to use dropna to clean up
+    seasonal_data = (
+      daily_tobegroupedby_season(daily_data, start_day, start_month, end_day, end_month)[daily_data.name]
+      .groupby(daily_tobegroupedby_season(daily_data, start_day, start_month, end_day, end_month)["seasons_starts"])
+      .sum(dim=time_coord, skipna=True, min_count=min_count)
+      .rename({"seasons_starts": time_coord})
+    )
+    seasons_ends = (
+      daily_tobegroupedby_season(daily_data, start_day, start_month, end_day, end_month)["seasons_ends"]
+      .rename({"group": time_coord})
+    )
+    summed_seasons = xr.merge([seasonal_data, seasons_ends])
+    return summed_seasons
 
 def run_test_season_stuff():
-  import pyaconf
-  import os
-  from pathlib import Path
+    import pyaconf
+    import os
+    from pathlib import Path
 
-  CONFIG = pyaconf.load(os.environ["CONFIG"])
-  DR_PATH = CONFIG["daily_rainfall_path"]
-  RR_MRG_ZARR = Path(DR_PATH)
-  rr_mrg = read_zarr_data(RR_MRG_ZARR)
-  rr_mrg = rr_mrg.sel(T=slice("2000", "2004"))
+    CONFIG = pyaconf.load(os.environ["CONFIG"])
+    DR_PATH = CONFIG["daily_rainfall_path"]
+    RR_MRG_ZARR = Path(DR_PATH)
+    rr_mrg = read_zarr_data(RR_MRG_ZARR)
+    rr_mrg = rr_mrg.sel(T=slice("2000", "2004"))
 
-  print("the inputs to grouping")
-  print(
-    daily_tobegroupedby_season(rr_mrg.precip, 29, 11, 5, 2)
-  )
+    print("the inputs to grouping")
+    print(
+      daily_tobegroupedby_season(rr_mrg.precip, 29, 11, 5, 2)
+    )
 
-  print("the outputs of seasonal_sum")
-  print(
-    seasonal_sum(rr_mrg.precip, 29, 11, 5, 2, min_count=0)
-  )
+    print("the outputs of seasonal_sum")
+    print(
+      seasonal_sum(rr_mrg.precip, 29, 11, 5, 2, min_count=0)
+    )
 
-  print("some data")
-  print(
-    seasonal_sum(rr_mrg.precip, 29, 11, 5, 2, min_count=0).precip.isel(X=150, Y=150).values
-  )
+    print("some data")
+    print(
+      seasonal_sum(rr_mrg.precip, 29, 11, 5, 2, min_count=0).precip.isel(X=150, Y=150).values
+    )
 
 def strftimeb2int(strftimeb):
-  strftimeb_all = {
-    "Jan": 1,
-    "Feb": 2,
-    "Mar": 3,
-    "Apr": 4,
-    "May": 5,
-    "Jun": 6,
-    "Jul": 7,
-    "Aug": 8,
-    "Sep": 9,
-    "Oct": 10,
-    "Nov": 11,
-    "Dec": 12
-  }
-  strftimebint=strftimeb_all[strftimeb]
-  return strftimebint
+    strftimeb_all = {
+      "Jan": 1,
+      "Feb": 2,
+      "Mar": 3,
+      "Apr": 4,
+      "May": 5,
+      "Jun": 6,
+      "Jul": 7,
+      "Aug": 8,
+      "Sep": 9,
+      "Oct": 10,
+      "Nov": 11,
+      "Dec": 12
+    }
+    strftimebint=strftimeb_all[strftimeb]
+    return strftimebint
 
 run_test_season_stuff()
 

--- a/onset_maproom/calc.py
+++ b/onset_maproom/calc.py
@@ -56,6 +56,25 @@ def onset_date(
 # Time functions
 
 
+def strftimeb2int(strftimeb):
+    strftimeb_all = {
+        "Jan": 1,
+        "Feb": 2,
+        "Mar": 3,
+        "Apr": 4,
+        "May": 5,
+        "Jun": 6,
+        "Jul": 7,
+        "Aug": 8,
+        "Sep": 9,
+        "Oct": 10,
+        "Nov": 11,
+        "Dec": 12,
+    }
+    strftimebint = strftimeb_all[strftimeb]
+    return strftimebint
+
+
 def daily_tobegroupedby_season(
     daily_data, start_day, start_month, end_day, end_month, time_coord="T"
 ):
@@ -83,17 +102,11 @@ def daily_tobegroupedby_season(
         end_month2 = 3
     # Find seasons edges
     start_edges = daily_data[time_coord].where(
-        (
-            (daily_data[time_coord].dt.day == start_day)
-            & (daily_data[time_coord].dt.month == start_month)
-        ),
+        lambda x: (x.dt.day == start_day) & (x.dt.month == start_month),
         drop=True,
     )
     end_edges = daily_data[time_coord].where(
-        (
-            (daily_data[time_coord].dt.day == end_day2)
-            & (daily_data[time_coord].dt.month == end_month2)
-        ),
+        lambda x: (x.dt.day == end_day2) & (x.dt.month == end_month2),
         drop=True,
     )
     # Drop dates outside very first and very last edges
@@ -131,6 +144,9 @@ def daily_tobegroupedby_season(
     return daily_tobegroupedby_season
 
 
+# Seasonal Functions
+
+
 def seasonal_sum(
     daily_data,
     start_day,
@@ -153,6 +169,9 @@ def seasonal_sum(
     seasons_ends = grouped_daily_data["seasons_ends"].rename({"group": time_coord})
     summed_seasons = xr.merge([seasonal_data, seasons_ends])
     return summed_seasons
+
+
+# Testing Functions
 
 
 def run_test_season_stuff():
@@ -202,25 +221,6 @@ def run_test_season_stuff():
         .isel(X=150, Y=150)
         .values
     )
-
-
-def strftimeb2int(strftimeb):
-    strftimeb_all = {
-        "Jan": 1,
-        "Feb": 2,
-        "Mar": 3,
-        "Apr": 4,
-        "May": 5,
-        "Jun": 6,
-        "Jul": 7,
-        "Aug": 8,
-        "Sep": 9,
-        "Oct": 10,
-        "Nov": 11,
-        "Dec": 12,
-    }
-    strftimebint = strftimeb_all[strftimeb]
-    return strftimebint
 
 
 run_test_season_stuff()

--- a/onset_maproom/calc.py
+++ b/onset_maproom/calc.py
@@ -103,15 +103,11 @@ def daily_tobegroupedby_season(
     if end_day == 29 and end_month == 2:
         end_edges = daily_data[time_coord].where(
             lambda x: (
-                (x + np.timedelta64(1, "D")).dt.day.squeeze(
-                    drop=True
-                )
+                (x + np.timedelta64(1, "D")).dt.day
                 == 1 
             )
             & (
-                (x + np.timedelta64(1, "D")).dt.month.squeeze(
-                    drop=True
-                )
+                (x + np.timedelta64(1, "D")).dt.month
                 == 3
             ),
             drop=True,

--- a/onset_maproom/calc.py
+++ b/onset_maproom/calc.py
@@ -113,14 +113,15 @@ def seasonal_sum(daily_data, start_day, start_month, end_day, end_month, min_cou
     """
     #It turns out that having daily_groupby_season concatenate only every other group is not enough to drop entired the undesired seasons
     #sum will return NaN for these so need to use dropna to clean up
+    grouped_daily_data = daily_tobegroupedby_season(daily_data, start_day, start_month, end_day, end_month)
     seasonal_data = (
-      daily_tobegroupedby_season(daily_data, start_day, start_month, end_day, end_month)[daily_data.name]
-      .groupby(daily_tobegroupedby_season(daily_data, start_day, start_month, end_day, end_month)["seasons_starts"])
+      grouped_daily_data[daily_data.name]
+      .groupby(grouped_daily_data["seasons_starts"])
       .sum(dim=time_coord, skipna=True, min_count=min_count)
       .rename({"seasons_starts": time_coord})
     )
     seasons_ends = (
-      daily_tobegroupedby_season(daily_data, start_day, start_month, end_day, end_month)["seasons_ends"]
+      grouped_daily_data["seasons_ends"]
       .rename({"group": time_coord})
     )
     summed_seasons = xr.merge([seasonal_data, seasons_ends])

--- a/onset_maproom/calc.py
+++ b/onset_maproom/calc.py
@@ -99,33 +99,27 @@ def daily_tobegroupedby_season(
         ),
         drop=True,
     )
-    end_edges = daily_data[time_coord].where(
-        (
-            (daily_data[time_coord].dt.day == end_day2)
-            & (daily_data[time_coord].dt.month == end_month2)
-        ),
-        drop=True,
+    end_edges = (
+        daily_data[time_coord]
+        .where(
+            (
+                (daily_data[time_coord].dt.day == end_day2)
+                & (daily_data[time_coord].dt.month == end_month2)
+            ),
+            drop=True,
+        )
+        .assign_coords(**{time_coord: start_edges[time_coord]})
     )
-    # Creates array of edges of the season that will form the bins
-    seasons_edges = xr.concat([start_edges, end_edges], "T_out", join="override")
     # Creates seasons_starts that will be used for grouping
     # and seasons_ends that is one of the outputs
     if end_day == 29 and end_month == 2:
         days_in_season = (
-            daily_data[time_coord]
-            >= seasons_edges.isel(T_out=0).rename({time_coord: "group"})
-        ) & (
-            daily_data[time_coord]
-            < seasons_edges.isel(T_out=1).rename({time_coord: "group"})
-        )
+            daily_data[time_coord] >= start_edges.rename({time_coord: "group"})
+        ) & (daily_data[time_coord] < end_edges.rename({time_coord: "group"}))
     else:
         days_in_season = (
-            daily_data[time_coord]
-            >= seasons_edges.isel(T_out=0).rename({time_coord: "group"})
-        ) & (
-            daily_data[time_coord]
-            <= seasons_edges.isel(T_out=1).rename({time_coord: "group"})
-        )
+            daily_data[time_coord] >= start_edges.rename({time_coord: "group"})
+        ) & (daily_data[time_coord] <= end_edges.rename({time_coord: "group"}))
     seasons_starts = daily_data[time_coord].where(days_in_season)
     seasons_starts = (
         xr.where(

--- a/onset_maproom/calc.py
+++ b/onset_maproom/calc.py
@@ -56,7 +56,6 @@ def daily_tobegroupedby_season(daily_data, start_day, start_month, end_day, end_
     if end_day == 29 and end_month == 2 :
       end_day2 = 1
       end_month2 = 3
-    #Drop date outside very first and very last edges -- this ensures we get complete seasons with regards to edges, later on
     start_edges = daily_data[time_coord].where(
       ((daily_data[time_coord].dt.day==start_day) & (daily_data[time_coord].dt.month==start_month)),
       drop=True
@@ -65,6 +64,7 @@ def daily_tobegroupedby_season(daily_data, start_day, start_month, end_day, end_
       ((daily_data[time_coord].dt.day==end_day2) & (daily_data[time_coord].dt.month==end_month2)),
       drop=True
     )
+    #Drop date outside very first and very last edges -- this ensures we get complete seasons with regards to edges, later on
     daily_data = daily_data.sel(**{time_coord: slice(start_edges[0],end_edges[-1])})
     start_edges = daily_data[time_coord].where(
       ((daily_data[time_coord].dt.day==start_day) & (daily_data[time_coord].dt.month==start_month)),

--- a/onset_maproom/calc.py
+++ b/onset_maproom/calc.py
@@ -27,11 +27,12 @@ def onset_date(
     time_coord="T",
 ):
     """Function reproducing Ingrid onsetDate function
-    http://iridl.ldeo.columbia.edu/dochelp/Documentation/details/index.html?func=onsetDate
+    http://iridl.ldeo.columbia.edu/dochelp/Documentation/details/index.html
     with the exception that:
     output is a random deltatime rather than an actual onset
     earlyStart input is now 2 arguments: day and month (as opposed to 1)
-    output is now the timedelta with each year's earlyStart (as opposed to the date itself)
+    output is now the timedelta with each year's earlyStart
+    (as opposed to the date itself)
     """
     onset_date = daily_rain[
         (daily_rain[time_coord].dt.day == early_start_day)
@@ -60,12 +61,16 @@ def daily_tobegroupedby_season(
 ):
     """Returns dataset ready to be grouped by with:
     the daily data where all days not in season of interest are dropped
-    season_starts: an array where the non-dropped days are indexed by the first day of their season -- to use to groupby
+    season_starts:
+      an array where the non-dropped days are indexed by the first day of their season
+      -- to use to groupby
     seasons_ends: an array with the dates of the end of the seasons
-    Can then apply groupby on daily_data against seasons_starts, and preserving seasons_ends for the record
+    Can then apply groupby on daily_data against seasons_starts,
+    and preserving seasons_ends for the record
     If starting day-month is 29-Feb, uses 1-Mar.
-    If ending day-month is 29-Feb, uses 1-Mar and triggers the option to open the right edge of the Interval.
-    That means that the last day included in the season will be 29-Feb in leap years and 28-Feb otherwise
+    If ending day-month is 29-Feb, uses 1-Mar and uses < rather than <=
+    That means that the last day included in the season will be 29-Feb in leap years
+    and 28-Feb otherwise
     """
     # Deal with leap year cases
     if start_day == 29 and start_month == 2:
@@ -91,7 +96,8 @@ def daily_tobegroupedby_season(
         ),
         drop=True,
     )
-    # Drop dates outside very first and very last edges -- this ensures we get complete seasons with regards to edges, later on
+    # Drop dates outside very first and very last edges
+    #  -- this ensures we get complete seasons with regards to edges, later on
     daily_data = daily_data.sel(**{time_coord: slice(start_edges[0], end_edges[-1])})
     start_edges = start_edges.sel(**{time_coord: slice(start_edges[0], end_edges[-1])})
     end_edges = end_edges.sel(

--- a/onset_maproom/calc.py
+++ b/onset_maproom/calc.py
@@ -2,14 +2,16 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
+#Date Reading functions
+
 def read_zarr_data(zarr_path):
   zarr_data = xr.open_zarr(zarr_path)
   return zarr_data
 
-#Onset Date function
+#Growing season functions
 
 def onset_date(daily_rain, early_start_day, early_start_month, search_days, rainy_day, running_days, running_total, min_rainy_days, dry_days, dry_spell, time_coord="T"):
-  """Fonction reproducing Ingrid onsetDate function
+  """Function reproducing Ingrid onsetDate function
   http://iridl.ldeo.columbia.edu/dochelp/Documentation/details/index.html?func=onsetDate
   with the exception that:
   output is a random deltatime rather than an actual onset
@@ -32,6 +34,80 @@ def onset_date(daily_rain, early_start_day, early_start_month, search_days, rain
 #Tip to get dates from timedelta  early_start_day
 #  onset_date = onset_date[time_coord] + onset_date  
   return onset_date
+
+# Time functions
+
+def daily_groupby_season(daily_data, start_day, start_month, end_day, end_month, time_coord="T"):
+  """Groups daily data by yearly seasons from day-month edges of season
+  Can then apply functions on each group to create yearly time series of seasonal quantities
+  If starting day-month is 29-Feb, uses 1-Mar.
+  If ending day-month is 29-Feb, uses 1-Mar and triggers the option to open the right edge of the Interval.
+  That means that the last day included in the season will be 29-Feb in leap years and 28-Feb otherwise
+  """
+#Deal with leap year cases
+  if start_day == 29 and start_month == 2 :
+    start_day = 1
+    start_month = 3
+  right_bool = True
+  if end_day == 29 and end_month == 2 :
+    end_day = 1
+    end_month = 3
+    right_bool = False
+#Creates array of edges of the season that will form the bins
+  season_bins = daily_data[time_coord].where(
+    ((daily_data[time_coord].dt.day==start_day) & (daily_data[time_coord].dt.month==start_month))
+    |
+    ((daily_data[time_coord].dt.day==end_day) & (daily_data[time_coord].dt.month==end_month)),
+    drop=True
+  )
+#First valid bin can be the 2nd one depending of order of first time_coord point, start/end day-month
+  first_valid_bin = ~((season_bins[0].dt.day == start_day) & (season_bins[0].dt.month == start_month)).values*1
+#First pass to group and then concat only every other season that we want to keep
+  daily_groubedby_season = xr.concat(
+    [daily_data.groupby_bins(time_coord, season_bins, right=right_bool)[g] for g in list(daily_data.groupby_bins(time_coord, season_bins, right=right_bool).groups.keys())[first_valid_bin::2]],
+    time_coord
+  )
+#Second pass to recreate the group labels that concat lost
+  daily_groubedby_season = daily_groubedby_season.groupby_bins(time_coord, season_bins, right=right_bool)
+  return daily_groubedby_season
+
+def seasonal_sum(daily_data, start_day, start_month, end_day, end_month, min_count=None, time_coord="T"):
+  """Calculates seasonal totals of daily data in season defined by day-month edges
+  """
+#It turns out that having daily_groupby_season concatenate only every other group is not enough to drop entired the undesired seasons
+#sum will return NaN for these so need to use dropna to clean up
+  summed_seasons = daily_groupby_season(daily_data, start_day, start_month, end_day, end_month).sum(dim=time_coord, skipna=True, min_count=min_count).dropna(time_coord + "_bins")
+  return summed_seasons
+
+def run_test_season_stuff():
+  import pyaconf
+  import os
+  from pathlib import Path
+
+  CONFIG = pyaconf.load(os.environ["CONFIG"])
+  DR_PATH = CONFIG["daily_rainfall_path"]
+  RR_MRG_ZARR = Path(DR_PATH)
+  rr_mrg = read_zarr_data(RR_MRG_ZARR)
+  rr_mrg = rr_mrg.sel(T=slice("2000", "2004"))
+
+#here, one can see clearly that we retain 4 labeled groups, the other every other groups are just not labeled
+#that's why we need to use dropna later on
+  print(
+    daily_groupby_season(rr_mrg, 29, 11, 5, 2)
+  )
+
+#Here we see we have the groups we want
+  print(
+    daily_groupby_season(rr_mrg, 29, 11, 5, 2).groups
+  )
+
+  print(
+    seasonal_sum(rr_mrg, 29, 11, 5, 2, min_count=0)
+  )
+
+  print(
+    seasonal_sum(rr_mrg, 29, 11, 5, 2, min_count=0).isel(X=150, Y=150).precip.values
+  )
 
 def strftimeb2int(strftimeb):
   strftimeb_all = {

--- a/onset_maproom/calc.py
+++ b/onset_maproom/calc.py
@@ -44,7 +44,7 @@ def daily_groupby_season(daily_data, start_day, start_month, end_day, end_month,
   If ending day-month is 29-Feb, uses 1-Mar and triggers the option to open the right edge of the Interval.
   That means that the last day included in the season will be 29-Feb in leap years and 28-Feb otherwise
   """
-#Deal with leap year cases
+  #Deal with leap year cases
   if start_day == 29 and start_month == 2 :
     start_day = 1
     start_month = 3
@@ -53,29 +53,29 @@ def daily_groupby_season(daily_data, start_day, start_month, end_day, end_month,
     end_day = 1
     end_month = 3
     right_bool = False
-#Creates array of edges of the season that will form the bins
+  #Creates array of edges of the season that will form the bins
   season_bins = daily_data[time_coord].where(
     ((daily_data[time_coord].dt.day==start_day) & (daily_data[time_coord].dt.month==start_month))
     |
     ((daily_data[time_coord].dt.day==end_day) & (daily_data[time_coord].dt.month==end_month)),
     drop=True
   )
-#First valid bin can be the 2nd one depending of order of first time_coord point, start/end day-month
+  #First valid bin can be the 2nd one depending of order of first time_coord point, start/end day-month
   first_valid_bin = ~((season_bins[0].dt.day == start_day) & (season_bins[0].dt.month == start_month)).values*1
-#First pass to group and then concat only every other season that we want to keep
+  #First pass to group and then concat only every other season that we want to keep
   daily_groubedby_season = xr.concat(
     [daily_data.groupby_bins(time_coord, season_bins, right=right_bool)[g] for g in list(daily_data.groupby_bins(time_coord, season_bins, right=right_bool).groups.keys())[first_valid_bin::2]],
     time_coord
   )
-#Second pass to recreate the group labels that concat lost
+  #Second pass to recreate the group labels that concat lost
   daily_groubedby_season = daily_groubedby_season.groupby_bins(time_coord, season_bins, right=right_bool)
   return daily_groubedby_season
 
 def seasonal_sum(daily_data, start_day, start_month, end_day, end_month, min_count=None, time_coord="T"):
   """Calculates seasonal totals of daily data in season defined by day-month edges
   """
-#It turns out that having daily_groupby_season concatenate only every other group is not enough to drop entired the undesired seasons
-#sum will return NaN for these so need to use dropna to clean up
+  #It turns out that having daily_groupby_season concatenate only every other group is not enough to drop entired the undesired seasons
+  #sum will return NaN for these so need to use dropna to clean up
   summed_seasons = daily_groupby_season(daily_data, start_day, start_month, end_day, end_month).sum(dim=time_coord, skipna=True, min_count=min_count).dropna(time_coord + "_bins")
   return summed_seasons
 
@@ -90,13 +90,13 @@ def run_test_season_stuff():
   rr_mrg = read_zarr_data(RR_MRG_ZARR)
   rr_mrg = rr_mrg.sel(T=slice("2000", "2004"))
 
-#here, one can see clearly that we retain 4 labeled groups, the other every other groups are just not labeled
-#that's why we need to use dropna later on
+  #here, one can see clearly that we retain 4 labeled groups, the other every other groups are just not labeled
+  #that's why we need to use dropna later on
   print(
     daily_groupby_season(rr_mrg, 29, 11, 5, 2)
   )
 
-#Here we see we have the groups we want
+  #Here we see we have the groups we want
   print(
     daily_groupby_season(rr_mrg, 29, 11, 5, 2).groups
   )

--- a/onset_maproom/calc.py
+++ b/onset_maproom/calc.py
@@ -90,26 +90,10 @@ def daily_tobegroupedby_season(
         ),
         drop=True,
     )
-    # Drop date outside very first and very last edges -- this ensures we get complete seasons with regards to edges, later on
+    # Drop dates outside very first and very last edges -- this ensures we get complete seasons with regards to edges, later on
     daily_data = daily_data.sel(**{time_coord: slice(start_edges[0], end_edges[-1])})
-    start_edges = daily_data[time_coord].where(
-        (
-            (daily_data[time_coord].dt.day == start_day)
-            & (daily_data[time_coord].dt.month == start_month)
-        ),
-        drop=True,
-    )
-    end_edges = (
-        daily_data[time_coord]
-        .where(
-            (
-                (daily_data[time_coord].dt.day == end_day2)
-                & (daily_data[time_coord].dt.month == end_month2)
-            ),
-            drop=True,
-        )
-        .assign_coords(**{time_coord: start_edges[time_coord]})
-    )
+    start_edges = start_edges.sel(**{time_coord: slice(start_edges[0],end_edges[-1])})
+    end_edges = end_edges.sel(**{time_coord: slice(start_edges[0],end_edges[-1])}).assign_coords(**{time_coord: start_edges[time_coord]})
     # Creates seasons_starts that will be used for grouping
     # and seasons_ends that is one of the outputs
     if end_day == 29 and end_month == 2:

--- a/onset_maproom/calc.py
+++ b/onset_maproom/calc.py
@@ -27,7 +27,7 @@ def onset_date(
     time_coord="T",
 ):
     """Function reproducing Ingrid onsetDate function
-    http://iridl.ldeo.columbia.edu/dochelp/Documentation/details/index.html
+    http://iridl.ldeo.columbia.edu/dochelp/Documentation/details/index.html?func=onsetDate
     with the exception that:
     output is a random deltatime rather than an actual onset
     earlyStart input is now 2 arguments: day and month (as opposed to 1)


### PR DESCRIPTION
Also includes seasonal_sum to illustrate how could be used to make "seasonal" functions.

The original plan was to make a generic function that will split 1D daily data into 2D daily data by days and years and select a subset of days defining a season. Thus allowing to perform analysis on the days dimension to obtain yearly series of a seasonal quantity and thus be able to reproduce a lot of popular Ingrid functions ([e.g.](http://iridl.ldeo.columbia.edu/dochelp/Documentation/details/index.html?func=flexseasonalfreqGT) and including onset date).

It turns out that xarray offers a [grouping function](http://xarray.pydata.org/en/stable/generated/xarray.DataArray.groupby.html) and more specifically by [bins](http://xarray.pydata.org/en/stable/generated/xarray.DataArray.groupby_bins.html) that then allow operations by group. This seems nicer to me as there is then no need to create a new dimension, worry about indexing and bins can have different sizes (making leap year management easier). The idea being to give the edges of the season of interest, group, then drop every other group and then that can be fed to any other operator.

So I went with that. Because bins are defined by their edges, I made the inputs for the season be start and end rather than start and length. Now that fits better the groupby_bins function and it's typically easier for a user to think of seasons in these terms. That may mean changing onset date function inputs accordingly, or maybe cover the 2 cases (ie also offer inputs to be start and length).

Now it also turns out that it's not easy to drop groups from a grouped object. Or it was but someone [complained](https://github.com/pydata/xarray/issues/1019) about automatically dropped empty bins so this [PR](https://github.com/pydata/xarray/pull/1027) brings them back automatically and recommends using dropna to actually drop. But one can do dropna only after applying an operator to the grouped data, so that is something to be aware of when creating something like seasonal_sum.

That makes me doubt whether this is a good route or not. The grouping thing is seducing but the dropping business not so much. Other options could be:

- use the pandas versions of those things ([groupby](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Series.groupby.html), [cut](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.cut.html)) and use [filter](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Series.filter.html) for dropping;
- go a totally different route, TBD

There is a run_test_season_stuff() to help with testing and one can run calc.py with
CONFIG=config-sample.yaml python calc.py