### PR TITLE
Restore outline of selected shape

### DIFF
--- a/fbfmaproom/fbfmaproom.py
+++ b/fbfmaproom/fbfmaproom.py
@@ -551,7 +551,7 @@ def _(pathname, position, mode, year):
         pixel = MultiPoint([(x0, y0), (x1, y1)]).envelope
         geom, _ = retrieve_geometry(country_key, tuple(c["marker"]), "0", None)
         if pixel.intersects(geom):
-            positions = [[[[y0, x0], [y1, x0], [y1, x1], [y0, x1], [y0, x0]]]]
+            positions = [[[[y0, x0], [y1, x0], [y1, x1], [y0, x1]]]]
             px = (x0 + x1) / 2
             pxs = "E" if px > 0.0 else "W" if px < 0.0 else ""
             py = (y0 + y1) / 2

--- a/fbfmaproom/fbfmaproom.py
+++ b/fbfmaproom/fbfmaproom.py
@@ -571,6 +571,20 @@ def _(pathname, position, mode, year):
     if positions is None:
         # raise PreventUpdate
         positions = ZERO_SHAPE
+
+    # The leaflet Polygon class supports a MultiPolygon option, but
+    # dash-leaflet's PropTypes rejects that format before Leaflet even
+    # gets a chance to see it. Until we can get that fixed, using
+    # the heuristic that the polygon with the most points in its outer
+    # ring is the most important one.
+    # https://github.com/thedirtyfew/dash-leaflet/issues/110
+    heuristic_size = lambda polygon: len(polygon[0])
+    longest_idx = max(
+        range(len(positions)),
+        key=lambda i: heuristic_size(positions[i])
+    )
+    positions = positions[longest_idx]
+
     return positions, key, [html.H3(title), html.Div(content)]
 
 


### PR DESCRIPTION
The map is supposed to display the shape of the selected region, but we broke that a while ago and didn't notice. This fixes it.