### PR TITLE
First test

### DIFF
--- a/onset_maproom/tests/test_calc.py
+++ b/onset_maproom/tests/test_calc.py
@@ -1,0 +1,39 @@
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+import calc
+
+def test_onset():
+
+    t = pd.date_range(start="2000-05-01", end="2000-06-30", freq="1D")
+    # this is rr_mrg.isel(X=0, Y=124, drop=True).sel(T=slice("2000-05-01", "2000-06-30"))
+    values = [
+        0.054383,  0.      ,  0.      ,  0.027983,  0.      ,  0.      ,
+        7.763758,  3.27952 , 13.375934,  4.271866, 12.16503 ,  9.706059,
+        7.048605,  0.      ,  0.      ,  0.      ,  0.872769,  3.166048,
+        0.117103,  0.      ,  4.584551,  0.787962,  6.474878,  0.      ,
+        0.      ,  2.834413,  9.029134,  0.      ,  0.269645,  0.793965,
+        0.      ,  0.      ,  0.      ,  0.191243,  0.      ,  0.      ,
+        4.617332,  1.748801,  2.079067,  2.046696,  0.415886,  0.264236,
+        2.72206 ,  1.153666,  0.204292,  0.      ,  5.239006,  0.      ,
+        0.      ,  0.      ,  0.      ,  0.679325,  2.525344,  2.432472,
+        10.737132,  0.598827,  0.87709 ,  0.162611, 18.794922,  3.82739 ,
+        2.72832
+    ]
+    precip = xr.DataArray(values, dims=["T"], coords={"T": t})
+
+    onsets = calc.onset_date(
+        daily_rain=precip,
+        wet_thresh=1,
+        wet_spell_length=3,
+        wet_spell_thresh=20,
+        min_wet_days=1,
+        dry_spell_length=7,
+        dry_spell_search=21,
+    )
+    assert pd.Timedelta(onsets.values) == pd.Timedelta(days=6)
+    # Converting to pd.Timedelta doesn't change the meaning of the
+    # assertion, but gives a more helpful error message when the test
+    # fails: Timedelta('6 days 00:00:00')
+    # vs. numpy.timedelta64(518400000000000,'ns')


### PR DESCRIPTION
A small example to illustrate writing automated unit tests. Gotta start somewhere.

These are a lot like the the print statements that Rémi has left commented out in a few places. They're a record of the things we checked during development to convince ourselves that a function behaves the way we expect. The difference between Rémi's print statements and automated tests is that the automated tests include expected outputs, and each test tells us clearly whether the actual output matches the expected output. We can run lots of these tests in a small amount of time (typically hundreds per second), which means when we make a change and accidentally break something, we can find out about it almost immediately, rather than days or years later when a user reports it.

To run the tests,
- Activate the conda environment that you use for this project.
- Run `conda install pytest` (only has to be done once, obviously). (In the future we need a better way to manage development dependencies like black and pytest.)
- Run `python -m pytest`. (Don't do just `pytest`, it won't work. Fixing this is on my todo list.)

After seeing the test pass, try changing the assertion to say `days=5` instead of `days=6`, and run it again to see it fail.

Some things to note:
- The test is self-contained. The input data are included in the test itself; it doesn't load data files from someplace like /data/remic. This is important for a few reasons.
  - We can run the test anywhere, e.g. a laptop that's not on the VPN, or in a GitHub Action that runs automatically on every pull request.
  - Because the input data are small, the test is fast. This makes it convenient to run all the tests frequently, which means we can get feedback as soon as we break something.
  - When something doesn't work the way we expect, the input data are easy to find and easy to inspect.
- I used test data that I had extracted from the real dataset, but you could just as well construct the data by hand, to check the function's behavior in a particular set of conditions.
- The test runner automatically runs any function whose name matches the pattern `test_*` that's in a file whose name matches `test_*.py`.

@remicousin @drewmresnick please add more tests. Here are some examples of scenarios that my example doesn't cover. You will probably come up with others.
- The example only has one year's data. We should have tests that find onset dates for multiple years.
- The example DataArray has only one dimension, T. We should have tests that also have X and Y. (But not too many. Make the tests only as complex as is needed to demonstrate the desired behavior; I think most of the behaviors we need to check can be verified on a one-dimensional dataset.)
- Demonstrate what happens when the input data are all NaN.
- Demonstrate that a dry spell within dry_spell_search days invalidates a wet spell; that a dry spell after dry_spell_search days doesn't invalidate it; etc.
- At one point I asked Rémi why we don't define a wet spell as beginning with a wet day, rather than searching for a wet spell and then searching for the first wet day within the wet spell. He pointed out that the two are not equivalent, because a wet spell can start with days when it rains more than zero but less than the threshold, and these contribute to the total. Write a test that would fail if I tried to implement my incorrect idea.

I suggest that we review and merge this PR now, and put other tests in subsequent PRs.