### PR TITLE
Easier configuration file management

### DIFF
--- a/fbfmaproom/fbfmaproom-sample.yaml
+++ b/fbfmaproom/fbfmaproom-sample.yaml
@@ -1,4 +1,4 @@
-mode: prod  # debug, devel or prod
+mode: debug  # debug, devel or prod
 prefix: https://iridl.ldeo.columbia.edu
 core_path: /fbfmaproom
 admin_path: /fbfmaproom-admin
@@ -26,8 +26,8 @@ bjoern:
     port: 8080
 
 dbpool:
-    name: design_engine  # postgres database name
-    host: localhost
+    name: DesignEngine  # postgres database name
+    host: pgdb12.iri.columbia.edu
     port: 5432
     user: dero  # user name
     password: SNIP

--- a/fbfmaproom/fbfmaproom.py
+++ b/fbfmaproom/fbfmaproom.py
@@ -32,7 +32,11 @@ import fbflayout
 import dash_bootstrap_components as dbc
 
 
-CONFIG = pyaconf.load(os.environ["CONFIG"])
+config_files = os.environ["CONFIG"].split(":")
+
+CONFIG = {}
+for fname in config_files:
+    CONFIG = pyaconf.merge([CONFIG, pyaconf.load(fname)])
 
 DBPOOL = pingrid.init_dbpool("dbpool", CONFIG)
 


### PR DESCRIPTION
Trying to make it less onerous for a developer to keep his configuration file up to date.
- fbfmaproom-sample.yaml is now geared towards developers, rather than being a prescription for how it should be configured in production.
- You can now set CONFIG to a colon-separated list of yaml files, where values set in files that come later in the list override values set in earlier files. Now you can use fbfmaproom-sample.yaml directly, rather than maintaining a separate copy that you have to update every time the sample file changes.
