### PR TITLE
download_table: represent bad_year as float rather than bool

### DIFF
--- a/fbfmaproom/__about__.py
+++ b/fbfmaproom/__about__.py
@@ -4,4 +4,4 @@
 name = "fbfmaproom"
 author = "IRI, Columbia University"
 email = "help@iri.columbia.edu"
-version = "2.13.0"
+version = "2.14.0"

--- a/fbfmaproom/fbfmaproom.py
+++ b/fbfmaproom/fbfmaproom.py
@@ -1083,6 +1083,7 @@ def download_table():
     df = main_ds.to_dataframe()
     time = df.index.map(lambda x: x.strftime('%Y-%m-%d'))
     df["time"] = time
+    df["bad_year"] = df["bad_year"].astype("float") # to acommodate NaN as missing value indicator
 
     cols = (
         ["time", "bad_year", "obs", "enso_state"] +

--- a/fbfmaproom/tests/test_fbfmaproom.py
+++ b/fbfmaproom/tests/test_fbfmaproom.py
@@ -238,14 +238,14 @@ def test_download_table():
             '&mode=0'
             '&geom_key=ET05'
         )
-    print(resp.data)
+    #print(resp.data)
     assert resp.status_code == 200
     assert resp.mimetype == "text/csv"
     csv_file = io.StringIO(resp.get_data(as_text=True))
     df = pd.read_csv(csv_file)
     onerow = df[df["time"] == "2019-04-16"]
     assert len(onerow) == 1
-    assert onerow["bad_year"].values[0] == 0
+    assert onerow["bad_year"].values[0] == 0.0
     assert onerow["obs"].values[0] == 3902.611
     assert onerow["pnep_30"].values[0] == 33.700127
     assert onerow["enso_state"].values[0] == "El Niño"


### PR DESCRIPTION
to acommodate NaN as the missing value indicator (ints have no NaN value).