### PR TITLE
NaNs in table; Ethiopia December issue

### DIFF
--- a/fbfmaproom/__about__.py
+++ b/fbfmaproom/__about__.py
@@ -4,4 +4,4 @@
 name = "fbfmaproom"
 author = "IRI, Columbia University"
 email = "help@iri.columbia.edu"
-version = "2.16.0"
+version = "2.17.0"

--- a/fbfmaproom/fbfmaproom-sample.yaml
+++ b/fbfmaproom/fbfmaproom-sample.yaml
@@ -1,4 +1,10 @@
 mode: debug  # debug, devel or prod
+
+# use 0.0.0.0 if you want to connect from another machine. Only
+# affects development configuration.
+dev_server_interface: 127.0.0.1
+dev_server_port: 8050
+
 prefix: https://iridl.ldeo.columbia.edu
 core_path: /fbfmaproom
 admin_path: /fbfmaproom-admin

--- a/fbfmaproom/fbfmaproom-sample.yaml
+++ b/fbfmaproom/fbfmaproom-sample.yaml
@@ -264,7 +264,7 @@ countries:
                 target_month: 3.5
                 length: 3.0
                 issue_months: [11, 0, 1]
-                year_range: [1983, 2021]
+                year_range: [1983, 2022]
     ethiopia-ond:
         logo: Ethiopia_IRI_98x48.png
         resolution: [.25, .25]

--- a/fbfmaproom/fbfmaproom.py
+++ b/fbfmaproom/fbfmaproom.py
@@ -456,11 +456,20 @@ def format_pnep(x):
 
 
 def format_bad(x):
-    if x is pd.NA:
+    # TODO some parts of the program use pandas boolean arrays, which
+    # use pd.NA as the missing value indicator, while others use
+    # xarray, which uses np.nan. This is annoying; I think we need to
+    # stop using boolean arrays. They're marked experimental in the
+    # pandas docs anyway.
+    if pd.isna(x):
         return None
-    if x:
+    if np.isnan(x):
+        return None
+    if x is True:
         return "Bad"
-    return ""
+    if x is False:
+        return ""
+    raise Exception(f"Invalid bad_year value {x}")
 
 
 def format_main_table(main_df, season_length, table_columns, severity):

--- a/fbfmaproom/fbfmaproom.py
+++ b/fbfmaproom/fbfmaproom.py
@@ -1112,7 +1112,7 @@ if __name__ == "__main__":
     else:
         debug = False
 
-    APP.run_server("127.0.0.1", 8050,
+    APP.run_server(CONFIG["dev_server_interface"], CONFIG["dev_server_port"],
         debug=debug,
         extra_files=config_files,
     )


### PR DESCRIPTION
I had previously made a change that was supposed to allowe missing values in the bad_years column, but I hadn't tested it yet. A bug became apparent when I tried extending the Ethiopia table to 2022.

Also moving dev server interface and port to the config file so we don't have to change it in fbfmaproom.py and risk accidentally committing the change.