### PR TITLE
Fix bug in trigger check endpoint

### DIFF
--- a/fbfmaproom/__about__.py
+++ b/fbfmaproom/__about__.py
@@ -4,4 +4,4 @@
 name = "fbfmaproom"
 author = "IRI, Columbia University"
 email = "help@iri.columbia.edu"
-version = "2.17.0"
+version = "2.17.1"

--- a/fbfmaproom/fbfmaproom.py
+++ b/fbfmaproom/fbfmaproom.py
@@ -1026,8 +1026,13 @@ def pnep_percentile():
     season_config = config["seasons"][season]
 
     target_month0 = season_config["target_month"]
-    l = (target_month0 - issue_month0) % 12
-    issue_date = cftime.Datetime360Day(season_year, target_month0 - l + 1, 1)
+
+    if issue_month0 > target_month0:
+        issue_year = season_year - 1
+    else:
+        issue_year = season_year
+
+    issue_date = cftime.Datetime360Day(issue_year, issue_month0, 1)
 
     if mode == "pixel":
         geom_key = bounds

--- a/fbfmaproom/tests/test_fbfmaproom.py
+++ b/fbfmaproom/tests/test_fbfmaproom.py
@@ -228,6 +228,26 @@ def test_pnep_percentile_region():
     assert np.isclose(d["probability"], 14.6804)
     assert d["triggered"] is False
 
+def test_pnep_percentile_straddle():
+    "Lead time spans Jan 1"
+    with fbfmaproom.SERVER.test_client() as client:
+        r = client.get(
+            "/fbfmaproom/pnep_percentile?country_key=malawi"
+            "&mode=0"
+            "&season=season1"
+            "&issue_month=10"
+            "&season_year=2021"
+            "&freq=30.0"
+            "&prob_thresh=30.31437"
+            "&region=152"
+        )
+    print(r.data)
+    assert r.status_code == 200
+    d = r.json
+    assert np.isclose(d["probability"], 33.10532)
+    assert d["triggered"] is True
+
+
 def test_download_table():
     with fbfmaproom.SERVER.test_client() as client:
         resp = client.get(


### PR DESCRIPTION
@jturmelle reported that the following trigger check URL fails with a 500 error:

https://iridl.ldeo.columbia.edu/fbfmaproom2/pnep_percentile?country_key=malawi&mode=0&issue_month=10&season_year=2021&freq=30.0&season=season1&prob_thresh=30.314374923706055&region=152

@kgraaf reviewing this seems like as good a place as any for you to get your feet wet with the FBF application.