### PR TITLE
set pnep url to be blank when no forecast is available

### DIFF
--- a/fbfmaproom/__about__.py
+++ b/fbfmaproom/__about__.py
@@ -4,4 +4,4 @@
 name = "fbfmaproom"
 author = "IRI, Columbia University"
 email = "help@iri.columbia.edu"
-version = "2.17.1"
+version = "2.18.0"

--- a/fbfmaproom/fbflayout.py
+++ b/fbfmaproom/fbflayout.py
@@ -358,6 +358,16 @@ def command_layout():
                     "vertical-align": "top",
                 },
             ),
+            dbc.Alert(
+                "No forecast available for this month",
+                color="danger",
+                dismissable=True,
+                is_open=False,
+                id="forecast_warning",
+                style={
+                    "margin-bottom": "8px",
+                },
+            ),
 
         ],
         id="command_panel",

--- a/fbfmaproom/fbflayout.py
+++ b/fbfmaproom/fbflayout.py
@@ -352,21 +352,13 @@ def command_layout():
                 ],
                 style={
                     "position": "relative",
-                    # "width": "1px", # force it to wrap
+                    "width": "1px", # force it to wrap
                     "display": "inline-block",
                     "padding": "10px",
                     "vertical-align": "top",
                 },
             ),
-            html.Div(id="command_msg",
-                     style={
-                         "position": "relative",
-                         "width": "110px",
-                         "display": "inline-block",
-                         "padding": "10px",
-                         "vertical-align": "top",
-                     },
-            ),
+
         ],
         id="command_panel",
         className="info",

--- a/fbfmaproom/fbflayout.py
+++ b/fbfmaproom/fbflayout.py
@@ -352,13 +352,21 @@ def command_layout():
                 ],
                 style={
                     "position": "relative",
-                    "width": "1px", # force it to wrap
+                    # "width": "1px", # force it to wrap
                     "display": "inline-block",
                     "padding": "10px",
                     "vertical-align": "top",
                 },
             ),
-
+            html.Div(id="command_msg",
+                     style={
+                         "position": "relative",
+                         "width": "110px",
+                         "display": "inline-block",
+                         "padding": "10px",
+                         "vertical-align": "top",
+                     },
+            ),
         ],
         id="command_panel",
         className="info",

--- a/fbfmaproom/fbfmaproom.py
+++ b/fbfmaproom/fbfmaproom.py
@@ -843,9 +843,13 @@ def pnep_tile_url_callback(target_year, issue_month_idx, freq, pathname, season_
     issue_month0 = season_config["issue_months"][issue_month_idx]
     target_month0 = season_config["target_month"]
 
-    # Prime the cache before the thundering horde of tile requests
-    select_pnep(country_key, issue_month0, target_month0, target_year, freq).data_array
-    return f"{TILE_PFX}/pnep/{{z}}/{{x}}/{{y}}/{country_key}/{season_id}/{target_year}/{issue_month_idx}/{freq}"
+    try:
+        # Prime the cache before the thundering horde of tile requests
+        select_pnep(country_key, issue_month0, target_month0, target_year, freq).data_array
+        return f"{TILE_PFX}/pnep/{{z}}/{{x}}/{{y}}/{country_key}/{season_id}/{target_year}/{issue_month_idx}/{freq}"
+    except:
+        # if no raster data can be created then set the URL to be blank
+        return ""
 
 
 @APP.callback(

--- a/fbfmaproom/fbfmaproom.py
+++ b/fbfmaproom/fbfmaproom.py
@@ -831,6 +831,7 @@ def _(
 
 @APP.callback(
     Output("pnep_layer", "url"),
+    Output("forecast_warning", "is_open"),
     Input("year", "value"),
     Input("issue_month", "value"),
     Input("freq", "value"),
@@ -846,10 +847,10 @@ def pnep_tile_url_callback(target_year, issue_month_idx, freq, pathname, season_
     try:
         # Prime the cache before the thundering horde of tile requests
         select_pnep(country_key, issue_month0, target_month0, target_year, freq).data_array
-        return f"{TILE_PFX}/pnep/{{z}}/{{x}}/{{y}}/{country_key}/{season_id}/{target_year}/{issue_month_idx}/{freq}"
+        return f"{TILE_PFX}/pnep/{{z}}/{{x}}/{{y}}/{country_key}/{season_id}/{target_year}/{issue_month_idx}/{freq}", False
     except Exception:
         # if no raster data can be created then set the URL to be blank
-        return ""
+        return "", True
 
 
 @APP.callback(

--- a/fbfmaproom/fbfmaproom.py
+++ b/fbfmaproom/fbfmaproom.py
@@ -831,6 +831,7 @@ def _(
 
 @APP.callback(
     Output("pnep_layer", "url"),
+    Output("command_msg", "children"),
     Input("year", "value"),
     Input("issue_month", "value"),
     Input("freq", "value"),
@@ -846,10 +847,10 @@ def pnep_tile_url_callback(target_year, issue_month_idx, freq, pathname, season_
     try:
         # Prime the cache before the thundering horde of tile requests
         select_pnep(country_key, issue_month0, target_month0, target_year, freq).data_array
-        return f"{TILE_PFX}/pnep/{{z}}/{{x}}/{{y}}/{country_key}/{season_id}/{target_year}/{issue_month_idx}/{freq}"
-    except:
+        return f"{TILE_PFX}/pnep/{{z}}/{{x}}/{{y}}/{country_key}/{season_id}/{target_year}/{issue_month_idx}/{freq}", ""
+    except Exception:
         # if no raster data can be created then set the URL to be blank
-        return ""
+        return "", "no forecast available for the selected month"
 
 
 @APP.callback(

--- a/fbfmaproom/fbfmaproom.py
+++ b/fbfmaproom/fbfmaproom.py
@@ -831,7 +831,6 @@ def _(
 
 @APP.callback(
     Output("pnep_layer", "url"),
-    Output("command_msg", "children"),
     Input("year", "value"),
     Input("issue_month", "value"),
     Input("freq", "value"),
@@ -847,10 +846,10 @@ def pnep_tile_url_callback(target_year, issue_month_idx, freq, pathname, season_
     try:
         # Prime the cache before the thundering horde of tile requests
         select_pnep(country_key, issue_month0, target_month0, target_year, freq).data_array
-        return f"{TILE_PFX}/pnep/{{z}}/{{x}}/{{y}}/{country_key}/{season_id}/{target_year}/{issue_month_idx}/{freq}", ""
+        return f"{TILE_PFX}/pnep/{{z}}/{{x}}/{{y}}/{country_key}/{season_id}/{target_year}/{issue_month_idx}/{freq}"
     except Exception:
         # if no raster data can be created then set the URL to be blank
-        return "", "no forecast available for the selected month"
+        return ""
 
 
 @APP.callback(


### PR DESCRIPTION
This solves the issue of erroneous forecast raster data being "left behind" when updated to a month for which there is no forecast