### PR TITLE
Draw borders on top of forecast layer to help users get their bearings

### DIFF
--- a/fbfmaproom/__about__.py
+++ b/fbfmaproom/__about__.py
@@ -4,4 +4,4 @@
 name = "fbfmaproom"
 author = "IRI, Columbia University"
 email = "help@iri.columbia.edu"
-version = "2.18.0"
+version = "2.19.0"

--- a/fbfmaproom/fbflayout.py
+++ b/fbfmaproom/fbflayout.py
@@ -56,6 +56,19 @@ def map_layout():
                         checked=False,
                     ),
                     dlf.Overlay(
+                        dlf.GeoJSON(
+                            id="borders",
+                            data={"features": []},
+                            options={
+                                "fill": False,
+                                "color": "black",
+                                "weight": .25,
+                            },
+                        ),
+                        name="Borders",
+                        checked=True,
+                    ),
+                    dlf.Overlay(
                         dlf.TileLayer(opacity=0.8, id="pnep_layer"),
                         name="Forecast",
                         checked=True,
@@ -76,7 +89,7 @@ def map_layout():
                         color="rgb(49, 109, 150)",
                         fillColor="orange",
                         fillOpacity=0.1,
-                        weight=1,
+                        weight=2,
                         id="feature",
                     ),
                     dlf.Marker(


### PR DESCRIPTION
Souha says people want to see regional borders drawn over the forecast data to help them understand out what part of the country they're looking at. They would like this done quickly as people are using it right now.

I want to continue refining the implementation (see TODO), but this version didn't take much time and I think it's good enough for now.

The vulnerability choropleth looks a little weird because the border rendering that happens on the back end doesn't exactly align with the rendering that happens on the front end; but we plan to get rid of the choropleth anyway and replace it with markers of varying size, so I don't think that's worth fixing.