### PR TITLE
Niger forecast v2

### DIFF
--- a/fbfmaproom/fbf-update-data.py
+++ b/fbfmaproom/fbf-update-data.py
@@ -59,7 +59,7 @@ datasets = [
     ),
     (
         'pnep-niger',
-        '/home/.aaron/.Niger/.Forecasts/.NextGen/.PRCPPRCP_CCAFCST_JAS/.NextGen/.FbF/.pne/S/(1%20Jan)/(1%20Feb)/(1%20Mar)/(1%20Apr)/(1%20May)/(1%20Jun)/VALUES/data.nc'
+        '/home/.aaron/.Niger/.Forecasts/.NextGen/.PRCPPRCP_CCAFCST_JAS_v2/.NextGen/.FbF/.pne/S/(1%20Jan)/(1%20Feb)/(1%20Mar)/(1%20Apr)/(1%20May)/(1%20Jun)/VALUES/data.nc'
     ),
     (
         'rain-guatemala',


### PR DESCRIPTION
Rémi made a new version of the forecast catalog entry last month, and it seems like I must have generated the zarr from his version, but I neglected to update this script with it.

Since I have no record of how I generated the zarr that's currently in prod, we should carefully compare it with the new one before overwriting it. It should be identical except for the addition of the February forecast.

We don't need to do a release/deploy for this, as the only file being changed is one that's not used in production.