### PR TITLE
Generate raster tiles with Mercantile and Pillow

### DIFF
--- a/onset_maproom/calc.py
+++ b/onset_maproom/calc.py
@@ -121,7 +121,6 @@ def onset_date(
                 dim=time_coord
             )
         ).astype("timedelta64[D]")
-        # ).astype(int)
         # delta from 1st day of time series
         - daily_rain[time_coord][0]
     ).rename("onset_delta")

--- a/onset_maproom/calc.py
+++ b/onset_maproom/calc.py
@@ -121,6 +121,7 @@ def onset_date(
                 dim=time_coord
             )
         ).astype("timedelta64[D]")
+        # ).astype(int)
         # delta from 1st day of time series
         - daily_rain[time_coord][0]
     ).rename("onset_delta")
@@ -330,3 +331,8 @@ def probExceed(onsetMD, search_start):
     cumsum["Days"] = onset_unique
     cumsum["probExceed"] = 1 - cumsum.onset / cumsum.onset[-1]
     return cumsum
+
+
+def days(da):
+    """convert time delta into number of days"""
+    return da / np.timedelta64(1, 'D')

--- a/onset_maproom/maproom.py
+++ b/onset_maproom/maproom.py
@@ -14,6 +14,8 @@ import plotly.graph_objects as pgo
 import plotly.express as px
 import pandas as pd
 import numpy as np
+import tile
+import io
 
 CONFIG = pyaconf.load(os.environ["CONFIG"])
 
@@ -45,6 +47,26 @@ APP = dash.Dash(
 APP.title = "Onset Maproom"
 
 APP.layout = layout.app_layout()
+
+@SERVER.route(
+    f"{TILE_PFX}/onset/<int:tz>/<int:tx>/<int:ty>/<int:wet_thresh>/<int:wet_spell_length>/<int:wet_spell_thresh>/<int:min_wet_days>/<int:dry_spell_length>/<int:dry_spell_search>"
+)
+def onset_tiles(tz, tx, ty, wet_thresh,
+                            wet_spell_length,
+                            wet_spell_thresh,
+                            min_wet_days,
+                            dry_spell_length,
+                            dry_spell_search,):
+    data = tile.tile_data(rr_mrg, tz, tx, ty)
+    # defaults are 1, 5, 20, 3, 7, 21
+    onset = calc.days(calc.onset_date(data.precip, wet_thresh,
+                                      wet_spell_length,
+                                      wet_spell_thresh,
+                                      min_wet_days,
+                                      dry_spell_length,
+                                      dry_spell_search,))
+    img = tile.make_image(onset, 0, 180) # hardcoded max for now but shouldn't be
+    return flask.send_file(img, mimetype="image/png")
 
 
 @APP.callback(
@@ -128,7 +150,7 @@ def onset_plots(click_lat_lng, search_start_day, search_start_month, searchDays,
     except TypeError:
         errorFig = pgo.Figure().add_annotation(x=2, y=2,text="No Data to Display",font=dict(family="sans serif",size=30,color="crimson"),showarrow=False, yshift=10, xshift=60)
         alert1 = dbc.Alert("Please ensure all input boxes are filled for the calculation to run.", color="danger", dismissable=True)
-        return errorFig, errorFig, alert1 #dash.no_update to leave the plat as-is and not show no data display    
+        return errorFig, errorFig, alert1 #dash.no_update to leave the plat as-is and not show no data display
     onsetDate = (onset_delta["T"] + onset_delta["onset_delta"])
     onsetDate = pd.DataFrame(onsetDate.values, columns = ['onset'])
     year = pd.DatetimeIndex(onsetDate["onset"]).year
@@ -143,7 +165,7 @@ def onset_plots(click_lat_lng, search_start_day, search_start_month, searchDays,
         return errorFig, errorFig, alert1
     onsetDate_graph = px.line(
         data_frame=onsetMD,
-        x="Year", 
+        x="Year",
         y="onset",
     )
     onsetDate_graph.update_traces(
@@ -152,8 +174,8 @@ def onset_plots(click_lat_lng, search_start_day, search_start_month, searchDays,
         connectgaps=False
     )
     onsetDate_graph.update_layout(
-        yaxis=dict(tickformat="%b %d"), 
-        xaxis_title="Year", 
+        yaxis=dict(tickformat="%b %d"),
+        xaxis_title="Year",
         yaxis_title="Onset Date",
         title= f"Starting dates of {int(search_start_day)} {search_start_month} season {year.min()}-{year.max()} ({round_latLng(lat)}N,{round_latLng(lng)}E)"
     )
@@ -172,7 +194,7 @@ def onset_plots(click_lat_lng, search_start_day, search_start_month, searchDays,
         xaxis_title=f"Onset Date [days since {search_start_day} {search_start_month}]"
     )
     return onsetDate_graph, probExceed_graph, None
-    
+
 
 if __name__ == "__main__":
     APP.run_server(debug=CONFIG["mode"] != "prod")

--- a/onset_maproom/tile.py
+++ b/onset_maproom/tile.py
@@ -1,0 +1,62 @@
+import io
+import numpy as np
+import xarray as xr
+import calc
+import mercantile
+from PIL import Image
+
+# example tile coordinates
+# https://a.tile.opentopomap.org/7/78/60.png
+
+
+def bounds(z, x, y):
+  """abstract over mercantile in case we move to morecantile (&c) in the
+  future, and reorder the dimensions to be consistent with the order in
+  the e.g. opentopomap standard"""
+  bounds = mercantile.bounds(x, y, z)
+  return bounds.north, bounds.south, bounds.west, bounds.east
+
+
+def tile_data(da, z, x, y):
+  """select the data specific to a single tile"""
+  north, south, west, east = bounds(z, x, y)
+  subset = da.sel(X=slice(west, east), Y=slice(south, north))
+  return subset
+
+def make_image(da, minimum, maximum, fn=None):
+  """we're doing the interpolation in PIL which may be less than ideal"""
+  prepared = da.clip(min=minimum, max=maximum).fillna(0)
+  pixels = prepared / maximum * 256
+  im = Image.fromarray(np.uint8(pixels), mode="L")
+  im2 = im.resize((256, 256), resample=Image.NEAREST)
+  if fn is not None:
+    out = fn
+    im2.save(out, format="PNG")
+  else:
+    out = io.BytesIO()
+    im2.save(out, format="PNG")
+    out.seek(0)
+  return out
+
+def onset_tile(fn, rr_mrg, tz, tx, ty, wet_thresh,
+                            wet_spell_length,
+                            wet_spell_thresh,
+                            min_wet_days,
+                            dry_spell_length,
+                            dry_spell_search,):
+    data = tile_data(rr_mrg, tz, tx, ty)
+    # defaults are 1, 5, 20, 3, 7, 21
+    onset = calc.days(calc.onset_date(data.precip, wet_thresh,
+                                      wet_spell_length,
+                                      wet_spell_thresh,
+                                      min_wet_days,
+                                      dry_spell_length,
+                                      dry_spell_search,))
+    make_image(onset, 0, 180, fn) # hardcoded max for now but shouldn't be
+
+
+
+# do this in PIL
+# def resample(da, width=256, height=256):
+#   size = da.sizes
+#   return da.interp(X = width / size['X'], Y = height / size['Y'], method="nearest")

--- a/onset_maproom/tile.py
+++ b/onset_maproom/tile.py
@@ -37,26 +37,3 @@ def make_image(da, minimum, maximum, fn=None):
     im2.save(out, format="PNG")
     out.seek(0)
   return out
-
-def onset_tile(fn, rr_mrg, tz, tx, ty, wet_thresh,
-                            wet_spell_length,
-                            wet_spell_thresh,
-                            min_wet_days,
-                            dry_spell_length,
-                            dry_spell_search,):
-    data = tile_data(rr_mrg, tz, tx, ty)
-    # defaults are 1, 5, 20, 3, 7, 21
-    onset = calc.days(calc.onset_date(data.precip, wet_thresh,
-                                      wet_spell_length,
-                                      wet_spell_thresh,
-                                      min_wet_days,
-                                      dry_spell_length,
-                                      dry_spell_search,))
-    make_image(onset, 0, 180, fn) # hardcoded max for now but shouldn't be
-
-
-
-# do this in PIL
-# def resample(da, width=256, height=256):
-#   size = da.sizes
-#   return da.interp(X = width / size['X'], Y = height / size['Y'], method="nearest")

--- a/onset_maproom/tile.py
+++ b/onset_maproom/tile.py
@@ -31,9 +31,9 @@ def make_image(da, minimum, maximum, fn=None):
   im2 = im.resize((256, 256), resample=Image.NEAREST)
   if fn is not None:
     out = fn
-    im2.save(out, format="PNG")
   else:
     out = io.BytesIO()
-    im2.save(out, format="PNG")
-    out.seek(0)
+  im2.save(out, format="PNG")
+  if fn is None:
+    out.seek(0) # won't work unless we seek to 0
   return out

--- a/onset_maproom/tile.py
+++ b/onset_maproom/tile.py
@@ -8,6 +8,29 @@ from PIL import Image
 # example tile coordinates
 # https://a.tile.opentopomap.org/7/78/60.png
 
+# this math isn't quite right but works well enough for now
+def generate_rainbow_palette():
+  pal = []
+  for g in range(64):
+    pal.append(0)   #R
+    pal.append(g*4) #G
+    pal.append(255) #B
+  for b in range(64)[::-1]:
+    pal.append(0)   #R
+    pal.append(255) #G
+    pal.append(b*4) #B
+  for r in range(64):
+    pal.append(r*4) #R
+    pal.append(255) #G
+    pal.append(0)   #B
+  for g in range(64)[::-1]:
+    pal.append(255) #R
+    pal.append(g*4) #G
+    pal.append(0)   #B
+  return pal
+
+palette = generate_rainbow_palette()
+
 
 def bounds(z, x, y):
   """abstract over mercantile in case we move to morecantile (&c) in the
@@ -27,13 +50,14 @@ def make_image(da, minimum, maximum, fn=None):
   """we're doing the interpolation in PIL which may be less than ideal"""
   prepared = da.clip(min=minimum, max=maximum).fillna(0)
   pixels = prepared / maximum * 256
-  im = Image.fromarray(np.uint8(pixels), mode="L")
-  im2 = im.resize((256, 256), resample=Image.NEAREST)
+  im = Image.fromarray(np.uint8(pixels), mode="P")
+  im.putpalette(palette)
+  im = im.resize((256, 256), resample=Image.NEAREST)
   if fn is not None:
     out = fn
   else:
     out = io.BytesIO()
-  im2.save(out, format="PNG")
+  im.save(out, format="PNG")
   if fn is None:
     out.seek(0) # won't work unless we seek to 0
   return out


### PR DESCRIPTION
This PR generates raster tiles with Mercantile and Pillow instead of Pingrid. Right now the images are in black and white, I'll need to add the colormap.

Working sample URL http://127.0.0.1:8050/onset-maproom-tiles/onset/7/78/60/1/5/20/3/7/21 (adjust host name and port accordingly of course)