### PR TITLE
Python dependency updates

### DIFF
--- a/onset_maproom/environment.yml
+++ b/onset_maproom/environment.yml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
+  - python=3.9
   - dash
   - dash-daq
   - flask

--- a/onset_maproom/environment_linux.yml
+++ b/onset_maproom/environment_linux.yml
@@ -11,22 +11,28 @@ dependencies:
   - asciitree=0.3.3=py_2
   - attrs=21.4.0=pyhd8ed1ab_0
   - blosc=1.21.0=h9c3ff4c_0
+  - bokeh=2.4.2=py39hf3d152e_0
   - boost-cpp=1.74.0=h6cacc03_7
-  - brotli-python=1.0.9=py310h122e73d_6
+  - brotli-python=1.0.9=py39he80948d_6
   - bzip2=1.0.8=h7f98852_4
   - c-ares=1.18.1=h7f98852_0
   - ca-certificates=2021.10.8=ha878542_0
   - cairo=1.16.0=ha00ac49_1009
+  - certifi=2021.10.8=py39hf3d152e_1
   - cfitsio=4.0.0=h9a35b8e_0
+  - cftime=1.5.2=py39hce5d2b2_0
+  - click=8.0.4=py39hf3d152e_0
   - click-plugins=1.1.1=py_0
   - cligj=0.7.2=pyhd8ed1ab_1
   - cloudpickle=2.0.0=pyhd8ed1ab_0
   - curl=7.81.0=h2574ce0_0
-  - dash=2.1.0=pyhd8ed1ab_1
+  - cytoolz=0.11.2=py39h3811e60_1
+  - dash=2.2.0=pyhd8ed1ab_0
   - dash-daq=0.5.0=pyh9f0ad1d_1
   - dask=2022.2.0=pyhd8ed1ab_0
   - dask-core=2022.2.0=pyhd8ed1ab_0
   - dbus=1.13.6=h5008d03_3
+  - distributed=2022.2.0=py39hf3d152e_0
   - expat=2.4.4=h9c3ff4c_0
   - fasteners=0.17.3=pyhd8ed1ab_0
   - ffmpeg=4.4.1=h6987444_1
@@ -42,7 +48,6 @@ dependencies:
   - freeglut=3.2.2=h9c3ff4c_1
   - freetype=2.10.4=h0708190_1
   - freexl=1.0.6=h7f98852_0
-  - fribidi=1.0.10=h36c2ea0_0
   - fsspec=2022.1.0=pyhd8ed1ab_0
   - geos=3.10.2=h9c3ff4c_0
   - geotiff=1.7.0=h6593c0a_6
@@ -58,6 +63,7 @@ dependencies:
   - hdf5=1.12.1=nompi_h2750804_103
   - heapdict=1.0.1=py_0
   - icu=69.1=h9c3ff4c_0
+  - importlib-metadata=4.11.1=py39hf3d152e_0
   - importlib_metadata=4.11.1=hd8ed1ab_0
   - itsdangerous=2.1.0=pyhd8ed1ab_0
   - jasper=2.0.33=ha77e612_0
@@ -90,7 +96,6 @@ dependencies:
   - libglu=9.0.0=he1b5a44_1001
   - libgomp=11.2.0=h1d223b6_12
   - libiconv=1.16=h516909a_0
-  - libimagequant=2.17.0=h7f98852_1
   - libkml=1.3.0=h238a007_1014
   - liblapack=3.9.0=13_linux64_openblas
   - liblapacke=3.9.0=13_linux64_openblas
@@ -100,7 +105,7 @@ dependencies:
   - libnsl=2.0.0=h7f98852_0
   - libogg=1.3.4=h7f98852_1
   - libopenblas=0.3.18=pthreads_h8fe5266_0
-  - libopencv=4.5.5=py31he7a5e20_2
+  - libopencv=4.5.5=py39h7d09d5f_2
   - libopus=1.3.1=h7f98852_1
   - libpciaccess=0.16=h516909a_0
   - libpng=1.6.37=h21135ba_2
@@ -124,20 +129,26 @@ dependencies:
   - libzlib=1.2.11=h36c2ea0_1013
   - locket=0.2.0=py_2
   - lz4-c=1.9.3=h9c3ff4c_1
-  - msgpack-python=1.0.3=py310h91b1402_0
+  - markupsafe=2.1.0=py39hb9d737c_0
+  - msgpack-python=1.0.3=py39h1a9c180_0
   - mysql-common=8.0.28=ha770c72_0
   - mysql-libs=8.0.28=hfa10184_0
   - ncurses=6.3=h9c3ff4c_0
+  - netcdf4=1.5.8=nompi_py39h64b754b_101
   - nettle=3.6=he412f7d_0
   - nspr=4.32=h9c3ff4c_1
   - nss=3.74=hb5efdd6_0
-  - opencv=4.5.5=py31hff52083_2
+  - numcodecs=0.9.1=py39he80948d_2
+  - numpy=1.22.2=py39h91f2184_0
+  - opencv=4.5.5=py39hf3d152e_2
   - openh264=2.1.1=h780b84a_0
   - openjpeg=2.4.0=hb52868f_1
   - openssl=1.1.1l=h7f98852_0
   - packaging=21.3=pyhd8ed1ab_0
+  - pandas=1.4.1=py39hde0f152_0
   - partd=1.2.0=pyhd8ed1ab_0
   - pcre=8.45=h9c3ff4c_0
+  - pillow=9.0.1=py39hae2aec6_2
   - pip=22.0.3=pyhd8ed1ab_0
   - pixman=0.40.0=h36c2ea0_0
   - plotly=5.6.0=pyhd8ed1ab_0
@@ -145,25 +156,32 @@ dependencies:
   - poppler-data=0.4.11=hd8ed1ab_0
   - postgresql=14.2=h2510834_0
   - proj=8.2.1=h277dcde_0
+  - psutil=5.9.0=py39h3811e60_0
+  - psycopg2=2.9.3=py39h3811e60_0
   - pthread-stubs=0.4=h36c2ea0_1001
-  - py-opencv=4.5.5=py31hfdc917e_2
+  - py-opencv=4.5.5=py39hef51801_2
   - pyparsing=3.0.7=pyhd8ed1ab_0
-  - python=3.10.2=h85951f9_3_cpython
+  - python=3.9.10=h85951f9_2_cpython
   - python-dateutil=2.8.2=pyhd8ed1ab_0
-  - python_abi=3.10=2_cp310
+  - python_abi=3.9=2_cp39
   - pytz=2021.3=pyhd8ed1ab_0
+  - pyyaml=6.0=py39h3811e60_3
   - qt=5.12.9=ha98a1a1_5
+  - rasterio=1.2.10=py39h0401cea_4
   - readline=8.1=h46c0cb4_0
+  - setuptools=59.8.0=py39hf3d152e_0
+  - shapely=1.8.0=py39ha65c37e_5
   - six=1.16.0=pyh6c4a22f_0
   - snuggs=1.4.7=py_0
   - sortedcontainers=2.4.0=pyhd8ed1ab_0
   - sqlite=3.37.0=h9cd32fc_0
-  - svt-av1=0.9.0=h9c3ff4c_0
+  - svt-av1=0.9.0=h27087fc_1
   - tblib=1.7.0=pyhd8ed1ab_0
   - tenacity=8.0.1=pyhd8ed1ab_0
   - tiledb=2.6.2=h2038895_1
   - tk=8.6.12=h27826a3_0
   - toolz=0.11.2=pyhd8ed1ab_0
+  - tornado=6.1=py39h3811e60_2
   - typing_extensions=4.1.1=pyha770c72_0
   - tzcode=2021e=h7f98852_0
   - tzdata=2021e=he74cb21_0
@@ -196,40 +214,17 @@ dependencies:
   - zlib=1.2.11=h36c2ea0_1013
   - zstd=1.5.2=ha95c52a_0
   - pip:
-    - bokeh==2.4.2
-    - brotli==1.0.9
-    - certifi==2021.10.8
-    - cftime==1.5.2
-    - click==8.0.3
-    - cytoolz==0.11.2
     - dash-bootstrap-components==1.0.3
     - dash-core-components==2.0.0
     - dash-extensions==0.0.71
     - dash-html-components==2.0.0
     - dash-leaflet==0.1.23
     - dash-table==5.0.0
-    - distributed==2022.2.0
     - editorconfig==0.12.3
     - flask-caching==1.10.1
     - geobuf==1.1.1
-    - importlib-metadata==4.11.1
     - jsbeautifier==1.14.0
-    - markupsafe==2.1.0
     - more-itertools==8.12.0
-    - msgpack==1.0.3
-    - netcdf4==1.5.8
-    - numcodecs==0.9.1
-    - numpy==1.22.2
-    - pandas==1.4.1
-    - pillow==9.0.1
     - protobuf==3.19.4
-    - psutil==5.9.0
-    - psycopg2==2.9.3
     - pyaconf==0.7.1
-    - pyyaml==6.0
     - queuepool==1.3.1
-    - rasterio==1.2.10
-    - setuptools==59.8.0
-    - shapely==1.8.0
-    - tornado==6.1
-prefix: /home/work/miniconda3/envs/onset

--- a/onset_maproom/environment_linux.yml
+++ b/onset_maproom/environment_linux.yml
@@ -1,4 +1,4 @@
-name: onset
+name: enactsmaproom
 channels:
   - conda-forge
   - defaults

--- a/onset_maproom/environment_linux.yml
+++ b/onset_maproom/environment_linux.yml
@@ -1,4 +1,4 @@
-name: enactsmaproom
+name: onset
 channels:
   - conda-forge
   - defaults
@@ -7,179 +7,174 @@ dependencies:
   - _openmp_mutex=4.5=1_gnu
   - affine=2.3.0=py_0
   - alsa-lib=1.2.3=h516909a_0
+  - aom=3.2.0=h9c3ff4c_2
   - asciitree=0.3.3=py_2
-  - attrs=21.2.0=pyhd8ed1ab_0
-  - bokeh=2.4.0=py39hf3d152e_0
-  - boost-cpp=1.74.0=h312852a_4
-  - brotli-python=1.0.9=py39he80948d_5
+  - attrs=21.4.0=pyhd8ed1ab_0
+  - blosc=1.21.0=h9c3ff4c_0
+  - boost-cpp=1.74.0=h6cacc03_7
+  - brotli-python=1.0.9=py310h122e73d_6
   - bzip2=1.0.8=h7f98852_4
-  - c-ares=1.17.2=h7f98852_0
-  - ca-certificates=2021.5.30=ha878542_0
-  - cairo=1.16.0=h6cf1ce9_1008
-  - cfitsio=3.470=hb418390_7
-  - cftime=1.5.1=py39hce5d2b2_0
-  - click=7.1.2=pyh9f0ad1d_0
+  - c-ares=1.18.1=h7f98852_0
+  - ca-certificates=2021.10.8=ha878542_0
+  - cairo=1.16.0=ha00ac49_1009
+  - cfitsio=4.0.0=h9a35b8e_0
   - click-plugins=1.1.1=py_0
-  - cligj=0.7.2=pyhd8ed1ab_0
+  - cligj=0.7.2=pyhd8ed1ab_1
   - cloudpickle=2.0.0=pyhd8ed1ab_0
-  - curl=7.79.1=h2574ce0_1
-  - cytoolz=0.11.0=py39h3811e60_3
-  - dash=2.0.0=pyhd8ed1ab_0
+  - curl=7.81.0=h2574ce0_0
+  - dash=2.1.0=pyhd8ed1ab_1
   - dash-daq=0.5.0=pyh9f0ad1d_1
-  - dask=2021.9.1=pyhd8ed1ab_0
-  - dask-core=2021.9.1=pyhd8ed1ab_0
-  - dataclasses=0.8=pyhc8e2a94_3
-  - dbus=1.13.6=h48d8840_2
-  - distributed=2021.9.1=py39hf3d152e_0
-  - expat=2.4.1=h9c3ff4c_0
-  - fasteners=0.16=pyhd8ed1ab_0
-  - ffmpeg=4.3.2=hca11adc_0
-  - flask=2.0.1=pyhd8ed1ab_0
+  - dask=2022.2.0=pyhd8ed1ab_0
+  - dask-core=2022.2.0=pyhd8ed1ab_0
+  - dbus=1.13.6=h5008d03_3
+  - expat=2.4.4=h9c3ff4c_0
+  - fasteners=0.17.3=pyhd8ed1ab_0
+  - ffmpeg=4.4.1=h6987444_1
+  - flask=2.0.3=pyhd8ed1ab_0
   - flask-compress=1.10.1=pyhd8ed1ab_0
   - font-ttf-dejavu-sans-mono=2.37=hab24e00_0
   - font-ttf-inconsolata=3.000=h77eed37_0
   - font-ttf-source-code-pro=2.038=h77eed37_0
   - font-ttf-ubuntu=0.83=hab24e00_0
-  - fontconfig=2.13.1=hba837de_1005
+  - fontconfig=2.13.96=ha180cfb_0
   - fonts-conda-ecosystem=1=0
   - fonts-conda-forge=1=0
+  - freeglut=3.2.2=h9c3ff4c_1
   - freetype=2.10.4=h0708190_1
   - freexl=1.0.6=h7f98852_0
-  - fsspec=2021.9.0=pyhd8ed1ab_0
-  - geos=3.9.1=h9c3ff4c_2
-  - geotiff=1.7.0=h08e826d_2
+  - fribidi=1.0.10=h36c2ea0_0
+  - fsspec=2022.1.0=pyhd8ed1ab_0
+  - geos=3.10.2=h9c3ff4c_0
+  - geotiff=1.7.0=h6593c0a_6
   - gettext=0.19.8.1=h73d1719_1008
   - giflib=5.2.1=h36c2ea0_2
-  - glib=2.68.4=h9c3ff4c_1
-  - glib-tools=2.68.4=h9c3ff4c_1
   - gmp=6.2.1=h58526e2_0
   - gnutls=3.6.13=h85f3911_1
   - graphite2=1.3.13=h58526e2_1001
-  - gst-plugins-base=1.18.5=hf529b03_0
-  - gstreamer=1.18.5=h76c114f_0
-  - harfbuzz=2.9.1=h83ec7ef_0
+  - gst-plugins-base=1.18.5=hf529b03_3
+  - gstreamer=1.18.5=h9f60fe5_3
+  - harfbuzz=3.4.0=hb4a5f5f_0
   - hdf4=4.2.15=h10796ff_3
-  - hdf5=1.12.1=nompi_h2750804_100
+  - hdf5=1.12.1=nompi_h2750804_103
   - heapdict=1.0.1=py_0
-  - icu=68.1=h58526e2_0
-  - itsdangerous=2.0.1=pyhd8ed1ab_0
-  - jasper=1.900.1=h07fcdf6_1006
+  - icu=69.1=h9c3ff4c_0
+  - importlib_metadata=4.11.1=hd8ed1ab_0
+  - itsdangerous=2.1.0=pyhd8ed1ab_0
+  - jasper=2.0.33=ha77e612_0
   - jbig=2.1=h7f98852_2003
-  - jinja2=3.0.1=pyhd8ed1ab_0
-  - jpeg=9d=h36c2ea0_0
+  - jinja2=3.0.3=pyhd8ed1ab_0
+  - jpeg=9e=h7f98852_0
   - json-c=0.15=h98cffda_0
   - kealib=1.4.14=h87e4c3c_3
-  - krb5=1.19.2=hcc1bbae_2
+  - krb5=1.19.2=hcc1bbae_3
   - lame=3.100=h7f98852_1001
   - lcms2=2.12=hddcbb42_0
   - ld_impl_linux-64=2.36.1=hea4e1c9_2
-  - lerc=2.2.1=h9c3ff4c_0
-  - libblas=3.9.0=11_linux64_openblas
-  - libcblas=3.9.0=11_linux64_openblas
-  - libclang=11.1.0=default_ha53f305_1
-  - libcurl=7.79.1=h2574ce0_1
+  - lerc=3.0=h9c3ff4c_0
+  - libblas=3.9.0=13_linux64_openblas
+  - libcblas=3.9.0=13_linux64_openblas
+  - libclang=13.0.1=default_hc23dcda_0
+  - libcurl=7.81.0=h2574ce0_0
   - libdap4=3.20.6=hd7c4107_2
-  - libdeflate=1.7=h7f98852_5
+  - libdeflate=1.10=h7f98852_0
+  - libdrm=2.4.109=h7f98852_0
   - libedit=3.1.20191231=he28a2e2_2
   - libev=4.33=h516909a_1
-  - libevent=2.1.10=hcdb4288_3
-  - libffi=3.4.2=h9c3ff4c_4
-  - libgcc-ng=11.2.0=h1d223b6_9
-  - libgdal=3.3.2=h6acdded_3
-  - libgfortran-ng=11.2.0=h69a702a_9
-  - libgfortran5=11.2.0=h5c6108e_9
-  - libglib=2.68.4=h174f98d_1
-  - libgomp=11.2.0=h1d223b6_9
+  - libevent=2.1.10=h9b69904_4
+  - libffi=3.4.2=h7f98852_5
+  - libgcc-ng=11.2.0=h1d223b6_12
+  - libgdal=3.4.1=hc3d8651_3
+  - libgfortran-ng=11.2.0=h69a702a_12
+  - libgfortran5=11.2.0=h5c6108e_12
+  - libglib=2.70.2=h174f98d_4
+  - libglu=9.0.0=he1b5a44_1001
+  - libgomp=11.2.0=h1d223b6_12
   - libiconv=1.16=h516909a_0
+  - libimagequant=2.17.0=h7f98852_1
   - libkml=1.3.0=h238a007_1014
-  - liblapack=3.9.0=11_linux64_openblas
-  - liblapacke=3.9.0=11_linux64_openblas
-  - libllvm11=11.1.0=hf817b99_2
+  - liblapack=3.9.0=13_linux64_openblas
+  - liblapacke=3.9.0=13_linux64_openblas
+  - libllvm13=13.0.1=hf817b99_0
   - libnetcdf=4.8.1=nompi_hb3fd0d9_101
-  - libnghttp2=1.43.0=h812cca2_1
+  - libnghttp2=1.46.0=h812cca2_0
+  - libnsl=2.0.0=h7f98852_0
   - libogg=1.3.4=h7f98852_1
-  - libopenblas=0.3.17=pthreads_h8fe5266_1
-  - libopencv=4.5.3=py39h3eb7741_2
+  - libopenblas=0.3.18=pthreads_h8fe5266_0
+  - libopencv=4.5.5=py31he7a5e20_2
   - libopus=1.3.1=h7f98852_1
+  - libpciaccess=0.16=h516909a_0
   - libpng=1.6.37=h21135ba_2
-  - libpq=13.3=hd57d9b9_0
-  - libprotobuf=3.16.0=h780b84a_0
-  - librttopo=1.1.0=h1185371_6
-  - libspatialite=5.0.1=h5cf074c_8
+  - libpq=14.2=hd57d9b9_0
+  - libprotobuf=3.19.4=h780b84a_0
+  - librttopo=1.1.0=hf69c175_9
+  - libspatialite=5.0.1=h0e567f8_14
   - libssh2=1.10.0=ha56f1ee_2
-  - libstdcxx-ng=11.2.0=he4da1e4_9
-  - libtiff=4.3.0=hf544144_1
+  - libstdcxx-ng=11.2.0=he4da1e4_12
+  - libtiff=4.3.0=h542a066_3
   - libuuid=2.32.1=h7f98852_1000
+  - libva=2.14.0=h7f98852_0
   - libvorbis=1.3.7=h9c3ff4c_0
-  - libwebp-base=1.2.1=h7f98852_0
-  - libxcb=1.13=h7f98852_1003
+  - libvpx=1.11.0=h9c3ff4c_3
+  - libwebp=1.2.2=h3452ae3_0
+  - libwebp-base=1.2.2=h7f98852_1
+  - libxcb=1.13=h7f98852_1004
   - libxkbcommon=1.0.3=he3ba5ed_0
-  - libxml2=2.9.12=h72842e0_0
+  - libxml2=2.9.12=h885dcf4_1
   - libzip=1.8.0=h4de3113_1
+  - libzlib=1.2.11=h36c2ea0_1013
   - locket=0.2.0=py_2
   - lz4-c=1.9.3=h9c3ff4c_1
-  - markupsafe=2.0.1=py39h3811e60_0
-  - monotonic=1.5=py_0
-  - msgpack-python=1.0.2=py39h1a9c180_1
-  - mysql-common=8.0.25=ha770c72_2
-  - mysql-libs=8.0.25=hfa10184_2
-  - ncurses=6.2=h58526e2_4
-  - netcdf4=1.5.7=nompi_py39h64b754b_102
+  - msgpack-python=1.0.3=py310h91b1402_0
+  - mysql-common=8.0.28=ha770c72_0
+  - mysql-libs=8.0.28=hfa10184_0
+  - ncurses=6.3=h9c3ff4c_0
   - nettle=3.6=he412f7d_0
-  - nspr=4.30=h9c3ff4c_0
-  - nss=3.69=hb5efdd6_0
-  - numcodecs=0.9.1=py39he80948d_0
-  - numpy=1.21.2=py39hdbf815f_0
-  - olefile=0.46=pyh9f0ad1d_1
-  - opencv=4.5.3=py39hf3d152e_2
+  - nspr=4.32=h9c3ff4c_1
+  - nss=3.74=hb5efdd6_0
+  - opencv=4.5.5=py31hff52083_2
   - openh264=2.1.1=h780b84a_0
   - openjpeg=2.4.0=hb52868f_1
   - openssl=1.1.1l=h7f98852_0
-  - packaging=21.0=pyhd8ed1ab_0
-  - pandas=1.3.3=py39hde0f152_0
+  - packaging=21.3=pyhd8ed1ab_0
   - partd=1.2.0=pyhd8ed1ab_0
   - pcre=8.45=h9c3ff4c_0
-  - pillow=8.3.2=py39ha612740_0
-  - pip=21.2.4=pyhd8ed1ab_0
+  - pip=22.0.3=pyhd8ed1ab_0
   - pixman=0.40.0=h36c2ea0_0
-  - plotly=5.3.1=pyhd8ed1ab_0
-  - poppler=21.09.0=ha39eefc_3
+  - plotly=5.6.0=pyhd8ed1ab_0
+  - poppler=22.01.0=ha39eefc_0
   - poppler-data=0.4.11=hd8ed1ab_0
-  - postgresql=13.3=h2510834_0
-  - proj=8.1.0=h277dcde_1
-  - psutil=5.8.0=py39h3811e60_1
-  - psycopg2=2.9.1=py39h3811e60_0
+  - postgresql=14.2=h2510834_0
+  - proj=8.2.1=h277dcde_0
   - pthread-stubs=0.4=h36c2ea0_1001
-  - py-opencv=4.5.3=py39hef51801_2
-  - pyparsing=2.4.7=pyh9f0ad1d_0
-  - python=3.9.7=hb7a2778_3_cpython
+  - py-opencv=4.5.5=py31hfdc917e_2
+  - pyparsing=3.0.7=pyhd8ed1ab_0
+  - python=3.10.2=h85951f9_3_cpython
   - python-dateutil=2.8.2=pyhd8ed1ab_0
-  - python_abi=3.9=2_cp39
-  - pytz=2021.1=pyhd8ed1ab_0
-  - pyyaml=5.4.1=py39h3811e60_1
-  - qt=5.12.9=hda022c4_4
-  - rasterio=1.2.8=py39h0d8c1d8_1
+  - python_abi=3.10=2_cp310
+  - pytz=2021.3=pyhd8ed1ab_0
+  - qt=5.12.9=ha98a1a1_5
   - readline=8.1=h46c0cb4_0
-  - setuptools=58.0.4=py39hf3d152e_2
-  - shapely=1.7.1=py39ha61afbd_5
   - six=1.16.0=pyh6c4a22f_0
   - snuggs=1.4.7=py_0
   - sortedcontainers=2.4.0=pyhd8ed1ab_0
-  - sqlite=3.36.0=h9cd32fc_2
+  - sqlite=3.37.0=h9cd32fc_0
+  - svt-av1=0.9.0=h9c3ff4c_0
   - tblib=1.7.0=pyhd8ed1ab_0
   - tenacity=8.0.1=pyhd8ed1ab_0
-  - tiledb=2.3.4=he87e0bf_0
-  - tk=8.6.11=h27826a3_1
-  - toolz=0.11.1=py_0
-  - tornado=6.1=py39h3811e60_1
-  - typing_extensions=3.10.0.2=pyha770c72_0
-  - tzcode=2021a=h7f98852_2
-  - tzdata=2021a=he74cb21_1
-  - werkzeug=2.0.1=pyhd8ed1ab_0
-  - wheel=0.37.0=pyhd8ed1ab_1
+  - tiledb=2.6.2=h2038895_1
+  - tk=8.6.12=h27826a3_0
+  - toolz=0.11.2=pyhd8ed1ab_0
+  - typing_extensions=4.1.1=pyha770c72_0
+  - tzcode=2021e=h7f98852_0
+  - tzdata=2021e=he74cb21_0
+  - werkzeug=2.0.3=pyhd8ed1ab_1
+  - wheel=0.37.1=pyhd8ed1ab_0
   - x264=1!161.3030=h7f98852_1
-  - xarray=0.19.0=pyhd8ed1ab_1
-  - xerces-c=3.2.3=h9d8b166_2
+  - x265=3.5=h4bd325d_1
+  - xarray=0.21.1=pyhd8ed1ab_0
+  - xerces-c=3.2.3=h8ce2273_4
+  - xorg-fixesproto=5.0=h7f98852_1002
+  - xorg-inputproto=2.3.2=h7f98852_1002
   - xorg-kbproto=1.0.7=h7f98852_1002
   - xorg-libice=1.0.10=h7f98852_0
   - xorg-libsm=1.2.3=hd9c2040_1000
@@ -187,26 +182,54 @@ dependencies:
   - xorg-libxau=1.0.9=h7f98852_0
   - xorg-libxdmcp=1.1.3=h7f98852_0
   - xorg-libxext=1.3.4=h7f98852_1
+  - xorg-libxfixes=5.0.3=h7f98852_1004
+  - xorg-libxi=1.7.10=h7f98852_0
   - xorg-libxrender=0.9.10=h7f98852_1003
   - xorg-renderproto=0.11.1=h7f98852_1002
   - xorg-xextproto=7.3.0=h7f98852_1002
   - xorg-xproto=7.0.31=h7f98852_1007
   - xz=5.2.5=h516909a_1
-  - yaml=0.2.5=h516909a_0
-  - zarr=2.10.0=pyhd8ed1ab_0
+  - yaml=0.2.5=h7f98852_2
+  - zarr=2.11.0=pyhd8ed1ab_0
   - zict=2.0.0=py_0
-  - zlib=1.2.11=h516909a_1010
-  - zstd=1.5.0=ha95c52a_0
+  - zipp=3.7.0=pyhd8ed1ab_1
+  - zlib=1.2.11=h36c2ea0_1013
+  - zstd=1.5.2=ha95c52a_0
   - pip:
-    - dash-bootstrap-components==0.13.1
+    - bokeh==2.4.2
+    - brotli==1.0.9
+    - certifi==2021.10.8
+    - cftime==1.5.2
+    - click==8.0.3
+    - cytoolz==0.11.2
+    - dash-bootstrap-components==1.0.3
     - dash-core-components==2.0.0
-    - dash-extensions==0.0.60
+    - dash-extensions==0.0.71
     - dash-html-components==2.0.0
-    - dash-leaflet==0.1.18
+    - dash-leaflet==0.1.23
     - dash-table==5.0.0
+    - distributed==2022.2.0
+    - editorconfig==0.12.3
     - flask-caching==1.10.1
     - geobuf==1.1.1
-    - more-itertools==8.10.0
-    - protobuf==3.18.0
+    - importlib-metadata==4.11.1
+    - jsbeautifier==1.14.0
+    - markupsafe==2.1.0
+    - more-itertools==8.12.0
+    - msgpack==1.0.3
+    - netcdf4==1.5.8
+    - numcodecs==0.9.1
+    - numpy==1.22.2
+    - pandas==1.4.1
+    - pillow==9.0.1
+    - protobuf==3.19.4
+    - psutil==5.9.0
+    - psycopg2==2.9.3
     - pyaconf==0.7.1
+    - pyyaml==6.0
     - queuepool==1.3.1
+    - rasterio==1.2.10
+    - setuptools==59.8.0
+    - shapely==1.8.0
+    - tornado==6.1
+prefix: /home/work/miniconda3/envs/onset

--- a/onset_maproom/layout.py
+++ b/onset_maproom/layout.py
@@ -305,7 +305,7 @@ def controls_layout():
             ),
         ],
         fluid=True,
-        className="scrollable-panel",
+        className="scrollable-panel p-3",
         style={"padding-bottom": "1rem", "padding-top": "1rem"},
     )
 

--- a/onset_maproom/layout.py
+++ b/onset_maproom/layout.py
@@ -108,7 +108,7 @@ def navbar_layout():
                             dbc.Select(
                                 id="select",
                                 value="en",
-                                bs_size="sm",
+                                size="sm",
                                 options=[
                                     {"label": "English", "value": "en"},
                                     {
@@ -168,7 +168,7 @@ def controls_layout():
                   dbc.Select(
                       id="date_input",
                       value="onset",
-                      bs_size="sm",
+                      size="sm",
                       options=[
                           {"label": "Onset", "value": "onset"},
                           {"label": "Cessation", "value": "cessation"},
@@ -180,7 +180,7 @@ def controls_layout():
                   dbc.Select(
                       id="yearly_stats_input",
                       value="mean",
-                      bs_size="sm",
+                      size="sm",
                       options=[
                           {"label": "Mean", "value": "mean"},
                           {"label": "Standard deviation", "value": "stddev"},

--- a/onset_maproom/layout.py
+++ b/onset_maproom/layout.py
@@ -1,7 +1,7 @@
 import dash_core_components as dcc
 import dash_html_components as html
 import dash_bootstrap_components as dbc
-import dash_table as table
+from dash import dash_table
 import dash_leaflet as dlf
 import plotly.express as px
 from widgets import Block, Sentence, Date, Units, Number

--- a/onset_maproom/layout.py
+++ b/onset_maproom/layout.py
@@ -43,7 +43,7 @@ def app_layout():
                                         },
                                     ),
                                 ],
-                                no_gutters=True,
+                                className="g-0",
                             ),
                             dbc.Row(
                                 [
@@ -59,7 +59,7 @@ def app_layout():
                                         },
                                     ),
                                 ],
-                                no_gutters=True,
+                                className="g-0",
                             ),
                         ],
                         sm=12,
@@ -67,7 +67,7 @@ def app_layout():
                         style={"background-color": "white"},
                     ),
                 ],
-                no_gutters=True,
+                className="g-0",
             ),
             html.Div(id="coord_alert",style={'position':'fixed','bottom':'0', 'width':'60%','right':'20px'}, children=[]),
         ],
@@ -96,7 +96,7 @@ def navbar_layout():
                         ),
                     ],
                     align="center",
-                    no_gutters=True,
+                    className="g-0",
                 ),
                 href="https://iridl.ldeo.columbia.edu",
             ),
@@ -125,8 +125,7 @@ def navbar_layout():
                             ),
                         ),
                     ],
-                    no_gutters=True,
-                    className="ml-auto flex-nowrap mt-3 mt-md-0",
+                    className="ml-auto flex-nowrap mt-3 mt-md-0 g-0",
                     align="center",
                 ),
                 id="navbar-collapse",
@@ -364,7 +363,7 @@ def results_layout():
                     )),
                     dbc.Spinner(dcc.Graph(
                         id="probExceed_graph",
-                    ))	
+                    ))
                 ],
                 label="Onset Date"
             ),

--- a/onset_maproom/layout.py
+++ b/onset_maproom/layout.py
@@ -1,5 +1,5 @@
-import dash_core_components as dcc
-import dash_html_components as html
+from dash import dcc
+from dash import html
 import dash_bootstrap_components as dbc
 from dash import dash_table
 import dash_leaflet as dlf

--- a/onset_maproom/maproom.py
+++ b/onset_maproom/maproom.py
@@ -1,7 +1,7 @@
 import os
 import flask
 import dash
-import dash_html_components as html
+from dash import html
 import dash_bootstrap_components as dbc
 from dash.dependencies import Output, Input, State
 import dash_leaflet as dlf
@@ -128,7 +128,7 @@ def onset_plots(click_lat_lng, search_start_day, search_start_month, searchDays,
     except TypeError:
         errorFig = pgo.Figure().add_annotation(x=2, y=2,text="No Data to Display",font=dict(family="sans serif",size=30,color="crimson"),showarrow=False, yshift=10, xshift=60)
         alert1 = dbc.Alert("Please ensure all input boxes are filled for the calculation to run.", color="danger", dismissable=True)
-        return errorFig, errorFig, alert1 #dash.no_update to leave the plat as-is and not show no data display    
+        return errorFig, errorFig, alert1 #dash.no_update to leave the plat as-is and not show no data display
     onsetDate = (onset_delta["T"] + onset_delta["onset_delta"])
     onsetDate = pd.DataFrame(onsetDate.values, columns = ['onset'])
     year = pd.DatetimeIndex(onsetDate["onset"]).year
@@ -143,7 +143,7 @@ def onset_plots(click_lat_lng, search_start_day, search_start_month, searchDays,
         return errorFig, errorFig, alert1
     onsetDate_graph = px.line(
         data_frame=onsetMD,
-        x="Year", 
+        x="Year",
         y="onset",
     )
     onsetDate_graph.update_traces(
@@ -152,8 +152,8 @@ def onset_plots(click_lat_lng, search_start_day, search_start_month, searchDays,
         connectgaps=False
     )
     onsetDate_graph.update_layout(
-        yaxis=dict(tickformat="%b %d"), 
-        xaxis_title="Year", 
+        yaxis=dict(tickformat="%b %d"),
+        xaxis_title="Year",
         yaxis_title="Onset Date",
         title= f"Starting dates of {int(search_start_day)} {search_start_month} season {year.min()}-{year.max()} ({round_latLng(lat)}N,{round_latLng(lng)}E)"
     )
@@ -172,7 +172,7 @@ def onset_plots(click_lat_lng, search_start_day, search_start_month, searchDays,
         xaxis_title=f"Onset Date [days since {search_start_day} {search_start_month}]"
     )
     return onsetDate_graph, probExceed_graph, None
-    
+
 
 if __name__ == "__main__":
     APP.run_server(debug=CONFIG["mode"] != "prod")

--- a/onset_maproom/widgets.py
+++ b/onset_maproom/widgets.py
@@ -1,7 +1,7 @@
 import dash_core_components as dcc
 import dash_html_components as html
 import dash_bootstrap_components as dbc
-import dash_table as table
+from dash import dash_table
 
 def Number(id, default, min=0, max=5):
     return [ dbc.Input(id=id, type="number", min=min, max=max,

--- a/onset_maproom/widgets.py
+++ b/onset_maproom/widgets.py
@@ -1,5 +1,5 @@
-import dash_core_components as dcc
-import dash_html_components as html
+from dash import dcc
+from dash import html
 import dash_bootstrap_components as dbc
 from dash import dash_table
 

--- a/onset_maproom/widgets.py
+++ b/onset_maproom/widgets.py
@@ -5,13 +5,13 @@ from dash import dash_table
 
 def Number(id, default, min=0, max=5):
     return [ dbc.Input(id=id, type="number", min=min, max=max,
-                     bs_size="sm", className="my-1",debounce=True,  value=str(default)) ]
+                       size="sm", className="m-1 d-inline-block w-auto",debounce=True,  value=str(default)) ]
 
 def Date(id, defaultDay, defaultMonth):
     return [
         dbc.Input(id=id + "day", type="number", min=1, max=31,
-                  bs_size="sm", className="my-1", debounce=True, value=str(defaultDay)),
-        dbc.Select(id=id + "month", value=defaultMonth, bs_size="sm", className="my-1",
+                  size="sm", className="m-1 d-inline-block w-auto", debounce=True, value=str(defaultDay)),
+        dbc.Select(id=id + "month", value=defaultMonth, size="sm", className="m-1 d-inline-block w-auto",
                    options=[
                        {"label": "January", "value": "Jan"},
                        {"label": "February", "value": "Feb"},
@@ -31,7 +31,7 @@ def Date(id, defaultDay, defaultMonth):
 
 def Units(id):
     return [
-        dbc.Select(id=id, value="/percent", bs_size="sm", className="my-1",
+        dbc.Select(id=id, value="/percent", size="sm", className="m-1 d-inline-block w-auto",
                    options=[
                        {"label": "fraction", "value": "/unitless"},
                        {"label": "%", "value": "/percent"},
@@ -47,25 +47,18 @@ def Sentence(*elems):
     if not isinstance(elems[0], str):
         start = 1
         tail = (len(elems) % 2) == 0
-        groups.append(dbc.FormGroup(elems[0], className="mr-2"))
+        groups.extend(elems[0])
 
     for i in range(start, len(elems) - (1 if tail else 0), 2):
         assert isinstance(elems[i], str)
-        groups.append(
-            dbc.FormGroup(
-                [dbc.Label(elems[i], size="sm", className="mr-2")] + elems[i + 1],
-                className="mr-2")
-        )
+        groups.append(dbc.Label(elems[i], size="sm", className="m-1 d-inline-block", width="auto"))
+        groups.extend(elems[i + 1])
 
     if tail:
         assert isinstance(elems[-1], str)
-        groups.append(
-            dbc.FormGroup([
-                dbc.Label(elems[-1], size="sm", className="mr-2"),
-            ], className="mr-2")
-        )
+        groups.append(dbc.Label(elems[-1], size="sm", className="m-1 d-inline-block", width="auto"))
 
-    return dbc.Form(groups, inline=True)
+    return dbc.Form(groups)
 
 
 def Block(title, *body):


### PR DESCRIPTION
Updates onset maproom to work correctly with newer version of the bootstrap components. Also fixes deprecation warnings.

- Downgraded environment to Python 3.9 to fix rasterio error
- Upgraded environment to v1 of Dash Bootstrap Components
- Fixed deprecation warnings by switching to importing from dash instead of dedicated packages (should have identical behavior)
- Switched `no_gutters` parameter to using bootstrap `g-0` class
- Switched deprecated `bs_size` parameter to `size`
- Removed `FormGroup` component and code designed to support it
- Added padding that was eliminated by removal of `FormGroup`s